### PR TITLE
Fix path of the binary inside the module image

### DIFF
--- a/desktop-module/Dockerfile
+++ b/desktop-module/Dockerfile
@@ -10,5 +10,5 @@ ENV BINARY_SUFFIX=""
 FROM suffix-$TARGETOS
 ARG TARGETARCH
 ARG TARGETOS
-COPY --from=dist dist/$TARGETOS-$TARGETARCH/docker-model$BINARY_SUFFIX /cli-plugins/desktop/$TARGETOS/docker-model$BINARY_SUFFIX
+COPY --from=dist dist/$TARGETOS-$TARGETARCH/docker-model$BINARY_SUFFIX /cli-plugins/model/$TARGETOS/docker-model$BINARY_SUFFIX
 COPY --from=desktop-module module-metadata.json /


### PR DESCRIPTION
The path inside the module image should be `/cli-plugins/<module-name>/<arch>/docker-<module-name>`
