### PR TITLE
Silence otel errors

### DIFF
--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -15,12 +15,18 @@ import (
 	"github.com/docker/pinata/common/pkg/inference/models"
 	"github.com/docker/pinata/common/pkg/paths"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
 )
 
 var ErrNotFound = errors.New("model not found")
 
+type otelErrorSilencer struct{}
+
+func (oes *otelErrorSilencer) Handle(error) {}
+
 func init() {
 	paths.Init(paths.OnHost)
+	otel.SetErrorHandler(&otelErrorSilencer{})
 }
 
 type Client struct {


### PR DESCRIPTION
https://docker.atlassian.net/browse/AIE-60

I didn't manage to properly root cause this. But I don shouldn't be vomiting otel logs at the user, so silence them.

Perhaps we could follow up with verbose logging options, in which case logging the otel stuff at a high verbosity may make sense.

Testing: Just run any command e.g. `docker model pull ...` with DD closed and check that no logs from otel are printed:

FAIL:

    $ docker model pull ignaciolopezluna020/deepseek-r1-distill-llama:8B-F16
    2025/03/19 12:29:59 failed to upload metrics: context deadline exceeded: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /Users/piotrs/.docker/run/user-analytics.otlp.grpc.sock: connect: connection refused"
    Failed to pull model: error querying /models/create: Post "http://localhost/exp/vDD4.40/models/create": dial unix /Users/piotrs/.docker/run/docker.sock: connect: connection refused

PASS:

    $ docker model pull ignaciolopezluna020/deepseek-r1-distill-llama:8B-F16
    Failed to pull model: error querying /models/create: Post "http://localhost/exp/vDD4.40/models/create": dial unix /Users/piotrs/.docker/run/docker.sock: connect: connection refused