### PR TITLE
list: Remove the "FORMAT" and "CREATED" columns

### DIFF
--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -8,9 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/pinata/common/pkg/engine"
@@ -260,7 +258,7 @@ func prettyPrintModels(models []Model) string {
 	var buf bytes.Buffer
 	table := tablewriter.NewWriter(&buf)
 
-	table.SetHeader([]string{"MODEL", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "FORMAT", "MODEL ID", "CREATED", "SIZE"})
+	table.SetHeader([]string{"MODEL", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "MODEL ID", "SIZE"})
 
 	table.SetBorder(false)
 	table.SetColumnSeparator("")
@@ -273,9 +271,7 @@ func prettyPrintModels(models []Model) string {
 		tablewriter.ALIGN_LEFT, // PARAMETERS
 		tablewriter.ALIGN_LEFT, // QUANTIZATION
 		tablewriter.ALIGN_LEFT, // ARCHITECTURE
-		tablewriter.ALIGN_LEFT, // FORMAT
 		tablewriter.ALIGN_LEFT, // IMAGE ID
-		tablewriter.ALIGN_LEFT, // CREATED
 		tablewriter.ALIGN_LEFT, // SIZE
 	})
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
@@ -294,34 +290,11 @@ func prettyPrintModels(models []Model) string {
 			m.Config.Parameters,
 			m.Config.Quantization,
 			m.Config.Architecture,
-			string(m.Config.Format),
 			m.ID[7:19],
-			timeAgo(time.Unix(m.Created, 0)),
 			m.Config.Size,
 		})
 	}
 
 	table.Render()
 	return buf.String()
-}
-
-func timeAgo(t time.Time) string {
-	duration := time.Since(t)
-	hours := int(duration.Hours())
-	days := hours / 24
-	months := days / 30
-	years := months / 12
-
-	switch {
-	case hours < 1:
-		return strconv.Itoa(int(duration.Minutes())) + " minutes ago"
-	case hours < 24:
-		return strconv.Itoa(hours) + " hours ago"
-	case days < 30:
-		return strconv.Itoa(days) + " days ago"
-	case months < 12:
-		return strconv.Itoa(months) + " months ago"
-	default:
-		return strconv.Itoa(years) + " years ago"
-	}
 }


### PR DESCRIPTION
Currently we only support the GGUF format. The "created" date we get for a model is the one when it's been published to Hub, so we can't determine when it was pulled locally and we've decided not to stat() the manifest file to grab this information.