### PR TITLE
list: Bring back the "CREATED" column, now in "HumanDuration"

### DIFF
--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -9,8 +9,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/client"
+	"github.com/docker/go-units"
 	"github.com/docker/pinata/common/pkg/engine"
 	"github.com/docker/pinata/common/pkg/inference"
 	"github.com/docker/pinata/common/pkg/inference/models"
@@ -258,7 +260,7 @@ func prettyPrintModels(models []Model) string {
 	var buf bytes.Buffer
 	table := tablewriter.NewWriter(&buf)
 
-	table.SetHeader([]string{"MODEL", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "MODEL ID", "SIZE"})
+	table.SetHeader([]string{"MODEL", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "MODEL ID", "CREATED", "SIZE"})
 
 	table.SetBorder(false)
 	table.SetColumnSeparator("")
@@ -271,7 +273,8 @@ func prettyPrintModels(models []Model) string {
 		tablewriter.ALIGN_LEFT, // PARAMETERS
 		tablewriter.ALIGN_LEFT, // QUANTIZATION
 		tablewriter.ALIGN_LEFT, // ARCHITECTURE
-		tablewriter.ALIGN_LEFT, // IMAGE ID
+		tablewriter.ALIGN_LEFT, // MODEL ID
+		tablewriter.ALIGN_LEFT, // CREATED
 		tablewriter.ALIGN_LEFT, // SIZE
 	})
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
@@ -291,6 +294,7 @@ func prettyPrintModels(models []Model) string {
 			m.Config.Quantization,
 			m.Config.Architecture,
 			m.ID[7:19],
+			units.HumanDuration(time.Since(time.Unix(m.Created, 0))) + " ago",
 			m.Config.Size,
 		})
 	}


### PR DESCRIPTION
Reverted in https://github.com/docker/model-cli/commit/bf06c26f054fb5e40c50f6ace2d948992655ff1c. Now using the same formatter as docker/cli: https://github.com/docker/cli/blob/b199ece92ab1daa5ce31b7c735b0284b25cea4f8/cli/command/config/formatter.go#L91.