### PR TITLE
Display specific error and enable steps if Docker Model Runner is not running

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -30,7 +30,8 @@ func newInspectCmd() *cobra.Command {
 			}
 			model, err = client.List(false, openai, model)
 			if err != nil {
-				return handleClientError(err, "Failed to list models")
+				err = handleClientError(err, "Failed to list models")
+				return handleNotRunningError(err)
 			}
 			cmd.Println(model)
 			return nil

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -30,7 +30,7 @@ func newInspectCmd() *cobra.Command {
 			}
 			model, err = client.List(false, openai, model)
 			if err != nil {
-				return fmt.Errorf("Failed to list models: %v\n", err)
+				return handleClientError(err, "Failed to list models")
 			}
 			cmd.Println(model)
 			return nil

--- a/commands/list.go
+++ b/commands/list.go
@@ -20,7 +20,7 @@ func newListCmd() *cobra.Command {
 			}
 			models, err := client.List(jsonFormat, openai, "")
 			if err != nil {
-				return fmt.Errorf("Failed to list models: %v\n", err)
+				return handleClientError(err, "Failed to list models")
 			}
 			cmd.Println(models)
 			return nil

--- a/commands/list.go
+++ b/commands/list.go
@@ -20,7 +20,8 @@ func newListCmd() *cobra.Command {
 			}
 			models, err := client.List(jsonFormat, openai, "")
 			if err != nil {
-				return handleClientError(err, "Failed to list models")
+				err = handleClientError(err, "Failed to list models")
+				return handleNotRunningError(err)
 			}
 			cmd.Println(models)
 			return nil

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -29,7 +29,8 @@ func newPullCmd() *cobra.Command {
 			}
 			response, err := client.Pull(model)
 			if err != nil {
-				return handleClientError(err, "Failed to pull model")
+				err = handleClientError(err, "Failed to pull model")
+				return handleNotRunningError(err)
 			}
 			cmd.Println(response)
 			return nil

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -29,7 +29,7 @@ func newPullCmd() *cobra.Command {
 			}
 			response, err := client.Pull(model)
 			if err != nil {
-				return fmt.Errorf("Failed to pull model: %v\n", err)
+				return handleClientError(err, "Failed to pull model")
 			}
 			cmd.Println(response)
 			return nil

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -29,7 +29,8 @@ func newRemoveCmd() *cobra.Command {
 			}
 			response, err := client.Remove(model)
 			if err != nil {
-				return handleClientError(err, "Failed to remove model")
+				err = handleClientError(err, "Failed to remove model")
+				return handleNotRunningError(err)
 			}
 			cmd.Println(response)
 			return nil

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -29,7 +29,7 @@ func newRemoveCmd() *cobra.Command {
 			}
 			response, err := client.Remove(model)
 			if err != nil {
-				return fmt.Errorf("Failed to remove model: %v\n", err)
+				return handleClientError(err, "Failed to remove model")
 			}
 			cmd.Println(response)
 			return nil

--- a/commands/run.go
+++ b/commands/run.go
@@ -39,19 +39,19 @@ func newRunCmd() *cobra.Command {
 
 			if _, err := client.List(false, false, model); err != nil {
 				if !errors.Is(err, desktop.ErrNotFound) {
-					return fmt.Errorf("Failed to list model: %v\n", err)
+					return handleClientError(err, "Failed to list models")
 				}
 				cmd.Println("Unable to find model '" + model + "' locally. Pulling from the server.")
 				response, err := client.Pull(model)
 				if err != nil {
-					return fmt.Errorf("Failed to pull model: %v\n", err)
+					return handleClientError(err, "Failed to pull model")
 				}
 				cmd.Println(response)
 			}
 
 			if prompt != "" {
 				if err := client.Chat(model, prompt); err != nil {
-					return fmt.Errorf("Failed to generate a response: %v\n", err)
+					return handleClientError(err, "Failed to generate a response")
 				}
 				cmd.Println()
 				return nil
@@ -75,7 +75,7 @@ func newRunCmd() *cobra.Command {
 				}
 
 				if err := client.Chat(model, userInput); err != nil {
-					cmd.PrintErrf("Failed to generate a response: %v\n", err)
+					cmd.PrintErr(handleClientError(err, "Failed to generate a response"))
 					cmd.Print("> ")
 					continue
 				}

--- a/commands/run.go
+++ b/commands/run.go
@@ -39,12 +39,12 @@ func newRunCmd() *cobra.Command {
 
 			if _, err := client.List(false, false, model); err != nil {
 				if !errors.Is(err, desktop.ErrNotFound) {
-					return handleClientError(err, "Failed to list models")
+					return handleNotRunningError(handleClientError(err, "Failed to list models"))
 				}
 				cmd.Println("Unable to find model '" + model + "' locally. Pulling from the server.")
 				response, err := client.Pull(model)
 				if err != nil {
-					return handleClientError(err, "Failed to pull model")
+					return handleNotRunningError(handleClientError(err, "Failed to pull model"))
 				}
 				cmd.Println(response)
 			}

--- a/commands/status.go
+++ b/commands/status.go
@@ -2,9 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func newStatusCmd() *cobra.Command {

--- a/commands/status.go
+++ b/commands/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,7 @@ func newStatusCmd() *cobra.Command {
 				cmd.Println("Docker Model Runner is running")
 			} else {
 				cmd.Println("Docker Model Runner is not running")
+				hooks.PrintNextSteps(os.Stdout, []string{enableViaCLI, enableViaGUI})
 				os.Exit(1)
 			}
 

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -1,15 +1,34 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 
+	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/model-cli/desktop"
 	"github.com/pkg/errors"
 )
 
+const (
+	enableViaCLI = "Enable Docker Model Runner via the CLI → docker desktop enable model-runner"
+	enableViaGUI = "Enable Docker Model Runner via the GUI → Go to Settings->Features in development->Enable Docker Model Runner"
+)
+
+var notRunningErr = fmt.Errorf("Docker Model Runner is not running. Please start it and try again.\n")
+
 func handleClientError(err error, message string) error {
 	if errors.Is(err, desktop.ErrServiceUnavailable) {
-		return fmt.Errorf("Docker Model Runner is not running. Please start it and try again.\n")
+		return notRunningErr
 	}
 	return errors.Wrap(err, message)
+}
+
+func handleNotRunningError(err error) error {
+	if errors.Is(err, notRunningErr) {
+		var buf bytes.Buffer
+		hooks.PrintNextSteps(&buf, []string{enableViaCLI, enableViaGUI})
+		return fmt.Errorf("%w\n%s", err, strings.TrimRight(buf.String(), "\n"))
+	}
+	return err
 }

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -1,0 +1,15 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/model-cli/desktop"
+	"github.com/pkg/errors"
+)
+
+func handleClientError(err error, message string) error {
+	if errors.Is(err, desktop.ErrServiceUnavailable) {
+		return fmt.Errorf("Docker Model Runner is not running. Please start it and try again.\n")
+	}
+	return errors.Wrap(err, message)
+}


### PR DESCRIPTION
Before:
```
$ docker model status
Docker Model Runner is not running
```

Now:
```
$ docker model status
Docker Model Runner is not running

What's next:
    Enable Docker Model Runner via the CLI → docker desktop enable model-runner
    Enable Docker Model Runner via the GUI → Go to Settings->Features in development->Enable Docker Model Runner
```

Before:
```
$ docker model run ai/smollm2
Failed to list model: failed to list models: 503 Service Unavailable
```

Now:
```
$ docker model run ai/smollm2
Docker Model Runner is not running. Please start it and try again.


What's next:
    Enable Docker Model Runner via the CLI → docker desktop enable model-runner
    Enable Docker Model Runner via the GUI → Go to Settings->Features in development->Enable Docker Model Runner
```

To build and install locally:
```
make clean && make link
```