### PR TITLE
rm multiple models

### DIFF
--- a/commands/rm.go
+++ b/commands/rm.go
@@ -9,26 +9,27 @@ import (
 
 func newRemoveCmd(desktopClient *desktop.Client) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "rm MODEL",
-		Short: "Remove a model downloaded from Docker Hub",
+		Use:   "rm [MODEL...]",
+		Short: "Remove models downloaded from Docker Hub",
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if len(args) < 1 {
 				return fmt.Errorf(
-					"'docker model rm' requires 1 argument.\n\n" +
-						"Usage:  docker model rm MODEL\n\n" +
+					"'docker model rm' requires at least 1 argument.\n\n" +
+						"Usage:  docker model rm [MODEL...]\n\n" +
 						"See 'docker model rm --help' for more information",
 				)
 			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			model := args[0]
-			response, err := desktopClient.Remove(model)
+			response, err := desktopClient.Remove(args)
+			if response != "" {
+				cmd.Println(response)
+			}
 			if err != nil {
 				err = handleClientError(err, "Failed to remove model")
 				return handleNotRunningError(err)
 			}
-			cmd.Println(response)
 			return nil
 		},
 	}


### PR DESCRIPTION
Allow to remove multiple model from the same command call
Could be useful to have the same capabilities as the main docker cli in the future
for example Docker CLI permits ```docker rm $(docker ps --filter status=exited -q)``` we could have the same `-q` attribut to `docker model list` and do `docker model rm $(docker model list -q)` to remove all the model at once