### PR TITLE
chore: Fix "call has arguments but no formatting directives"

### DIFF
--- a/commands/compose.go
+++ b/commands/compose.go
@@ -37,7 +37,7 @@ func newUpCommand(desktopClient *desktop.Client) *cobra.Command {
 				sendInfo(s)
 			})
 			if err != nil {
-				sendErrorf("Failed to pull model", err)
+				sendErrorf("Failed to pull model: %v", err)
 				return fmt.Errorf("Failed to pull model: %v\n", err)
 			}
 


### PR DESCRIPTION
Noticed this by running `go vet`.
```
$ go vet ./...
# github.com/docker/model-cli/commands
# [github.com/docker/model-cli/commands]
commands/compose.go:40:15: github.com/docker/model-cli/commands.sendErrorf call has arguments but no formatting directives
```
