### PR TITLE
list: Add -q, --quiet for only showing model IDs

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -24,7 +24,7 @@ func newInspectCmd(desktopClient *desktop.Client) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			model := args[0]
-			model, err := desktopClient.List(false, openai, model)
+			model, err := desktopClient.List(false, openai, false, model)
 			if err != nil {
 				err = handleClientError(err, "Failed to list models")
 				return handleNotRunningError(err)

--- a/commands/list.go
+++ b/commands/list.go
@@ -8,7 +8,7 @@ import (
 func newListCmd(desktopClient *desktop.Client) *cobra.Command {
 	var jsonFormat, openai bool
 	c := &cobra.Command{
-		Use:     "list",
+		Use:     "list [OPTIONS]",
 		Aliases: []string{"ls"},
 		Short:   "List the available models that can be run with the Docker Model Runner",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/commands/list.go
+++ b/commands/list.go
@@ -6,22 +6,23 @@ import (
 )
 
 func newListCmd(desktopClient *desktop.Client) *cobra.Command {
-	var jsonFormat, openai bool
+	var jsonFormat, openai, quiet bool
 	c := &cobra.Command{
 		Use:     "list [OPTIONS]",
 		Aliases: []string{"ls"},
 		Short:   "List the available models that can be run with the Docker Model Runner",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			models, err := desktopClient.List(jsonFormat, openai, "")
+			models, err := desktopClient.List(jsonFormat, openai, quiet, "")
 			if err != nil {
 				err = handleClientError(err, "Failed to list models")
 				return handleNotRunningError(err)
 			}
-			cmd.Println(models)
+			cmd.Print(models)
 			return nil
 		},
 	}
 	c.Flags().BoolVar(&jsonFormat, "json", false, "List models in a JSON format")
 	c.Flags().BoolVar(&openai, "openai", false, "List models in an OpenAI format")
+	c.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only show model IDs")
 	return c
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -32,7 +32,7 @@ func newRunCmd(desktopClient *desktop.Client) *cobra.Command {
 				}
 			}
 
-			if _, err := desktopClient.List(false, false, model); err != nil {
+			if _, err := desktopClient.List(false, false, false, model); err != nil {
 				if !errors.Is(err, desktop.ErrNotFound) {
 					return handleNotRunningError(handleClientError(err, "Failed to list models"))
 				}

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -135,7 +135,7 @@ func (c *Client) Pull(model string, progress func(string)) (string, bool, error)
 	return "", progressShown, fmt.Errorf("unexpected end of stream while pulling model %s", model)
 }
 
-func (c *Client) List(jsonFormat, openai bool, model string) (string, error) {
+func (c *Client) List(jsonFormat, openai bool, quiet bool, model string) (string, error) {
 	modelsRoute := inference.ModelsPrefix
 	if openai {
 		modelsRoute = inference.InferencePrefix + "/v1/models"
@@ -188,6 +188,22 @@ func (c *Client) List(jsonFormat, openai bool, model string) (string, error) {
 		}
 
 		return string(modelsJsonPretty), nil
+	}
+
+	if quiet {
+		var modelIDs string
+		for _, m := range modelsJson {
+			if len(m.Tags) == 0 {
+				fmt.Fprintf(os.Stderr, "no tags found for model: %v\n", m)
+				continue
+			}
+			if len(m.ID) < 19 {
+				fmt.Fprintf(os.Stderr, "invalid image ID for model: %v\n", m)
+				continue
+			}
+			modelIDs += fmt.Sprintf("%s\n", m.ID[7:19])
+		}
+		return modelIDs, nil
 	}
 
 	return prettyPrintModels(modelsJson), nil


### PR DESCRIPTION
```
$ # with Docker Desktop running:
$ make clean && make link
```

```
$ docker model list --help
Usage:  docker model list [OPTIONS]

List the available models that can be run with the Docker Model Runner

Aliases:
  docker model list, docker model ls

Options:
      --json     List models in a JSON format
      --openai   List models in an OpenAI format
  -q, --quiet    Only show model IDs
 ```

```
$ docker model ls
MODEL                       PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED      SIZE
ai/smollm2                  361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  2 weeks ago  256.35 MiB
ai/llama3.2:1B-Q8_0         1.24 B      Q8_0            llama         a15c3117eeeb  2 weeks ago  1.22 GiB
ghcr.io/ilopezluna/smollm2  134.52 M    Q2_K            llama         425de603d029  2 days ago   82.41 MiB
```

```
$ docker model ls -q
354bf30d0aa3
a15c3117eeeb
425de603d029
```

```
$ docker model rm $(docker model ls -q)
Model ai/smollm2 removed successfully
Model ai/llama3.2:1B-Q8_0 removed successfully
Model ghcr.io/ilopezluna/smollm2 removed successfully
```