### PR TITLE
Revert "run: Fix the "too many arguments" check"

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -92,7 +92,7 @@ func newRunCmd(desktopClient *desktop.Client) *cobra.Command {
 					"See 'docker model run --help' for more information",
 			)
 		}
-		if len(args) >= 2 {
+		if len(args) > 2 {
 			return fmt.Errorf("too many arguments, expected " + cmdArgs)
 		}
 		return nil


### PR DESCRIPTION
The check was actually correct because a prompt can be passed to run as a second argument.

This reverts commit 51497c08a1f7b7c260b9cba90068ac2cc36b519c.