### PR TITLE
fix: improve error message for non-existent model removal

### DIFF
--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -322,6 +322,15 @@ func (c *Client) Chat(model, prompt string) error {
 func (c *Client) Remove(models []string) (string, error) {
 	modelRemoved := ""
 	for _, model := range models {
+		// Check if not a model ID passed as parameter.
+		if !strings.Contains(model, "/") {
+			var err error
+			modelID := model
+			if model, err = c.modelNameFromID(model); err != nil {
+				return modelRemoved, fmt.Errorf("invalid model name: %s", modelID)
+			}
+		}
+
 		removePath := inference.ModelsPrefix + "/" + model
 		resp, err := c.doRequest(http.MethodDelete, removePath, nil)
 		if err != nil {


### PR DESCRIPTION
Align the error message format when removing non-existent models with Docker's image removal error format. 
Now it returns "no such model: <model_name>" which matches the pattern used by Docker's image removal command.

Example:
Before: "removing ai/lala failed with status 404 Not Found: not found"
After: "no such model: ai/lala"

**Update:** if the model name does not contain a slash, we assume its an id, if the if its not found then the error message will be different. 
We have to revisit that part