### PR TITLE
Allow run from a model ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ link:
 	@ln -sf $(shell pwd)/$(BINARY_NAME) $(PLUGIN_DIR)/$(PLUGIN_NAME)
 	@echo "Link created: $(PLUGIN_DIR)/$(PLUGIN_NAME)"
 
+install: build link
+
 release:
 	@if [ -z "$(VERSION)" ]; then \
 		echo "Error: VERSION parameter is required. Use: make release VERSION=x.y.z"; \

--- a/commands/completion/functions.go
+++ b/commands/completion/functions.go
@@ -1,8 +1,6 @@
 package completion
 
 import (
-	"encoding/json"
-
 	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
 )
@@ -17,12 +15,8 @@ func ModelNames(desktopClient *desktop.Client, limit int) cobra.CompletionFunc {
 		if limit > 0 && len(args) >= limit {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		modelsString, err := desktopClient.List(true, false, false, "")
+		models, err := desktopClient.List()
 		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-		var models []desktop.Model
-		if err := json.Unmarshal([]byte(modelsString), &models); err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
 		var names []string

--- a/commands/formatter/json.go
+++ b/commands/formatter/json.go
@@ -1,0 +1,23 @@
+package formatter
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+const standardIndentation = "    "
+
+// ToStandardJSON return a string with the JSON representation of the interface{}
+func ToStandardJSON(i interface{}) (string, error) {
+	return ToJSON(i, "", standardIndentation)
+}
+
+// ToJSON return a string with the JSON representation of the interface{}
+func ToJSON(i interface{}, prefix string, indentation string) (string, error) {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent(prefix, indentation)
+	err := encoder.Encode(i)
+	return buffer.String(), err
+}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -24,7 +24,7 @@ func newInspectCmd(desktopClient *desktop.Client) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inspectedModel, err := inpsectModel(args, openai, desktopClient)
+			inspectedModel, err := inspectModel(args, openai, desktopClient)
 			if err != nil {
 				return err
 			}
@@ -37,7 +37,7 @@ func newInspectCmd(desktopClient *desktop.Client) *cobra.Command {
 	return c
 }
 
-func inpsectModel(args []string, openai bool, desktopClient *desktop.Client) (string, error) {
+func inspectModel(args []string, openai bool, desktopClient *desktop.Client) (string, error) {
 	modelName := args[0]
 	if openai {
 		model, err := desktopClient.InspectOpenAI(modelName)

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -45,16 +45,12 @@ func inpsectModel(args []string, openai bool, desktopClient *desktop.Client) (st
 			err = handleClientError(err, "Failed to get model "+modelName)
 			return "", handleNotRunningError(err)
 		}
-		return model, nil
+		return formatter.ToStandardJSON(model)
 	}
 	model, err := desktopClient.Inspect(modelName)
 	if err != nil {
 		err = handleClientError(err, "Failed to get model "+modelName)
 		return "", handleNotRunningError(err)
 	}
-	jsonModel, err := formatter.ToStandardJSON(model)
-	if err != nil {
-		return "", err
-	}
-	return jsonModel, nil
+	return formatter.ToStandardJSON(model)
 }

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"fmt"
-
 	"github.com/docker/model-cli/commands/completion"
+	"github.com/docker/model-cli/commands/formatter"
 	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
 )
@@ -24,17 +24,37 @@ func newInspectCmd(desktopClient *desktop.Client) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			model := args[0]
-			model, err := desktopClient.List(false, openai, false, model)
+			inspectedModel, err := inpsectModel(args, openai, desktopClient)
 			if err != nil {
-				err = handleClientError(err, "Failed to list models")
-				return handleNotRunningError(err)
+				return err
 			}
-			cmd.Println(model)
+			cmd.Print(inspectedModel)
 			return nil
 		},
 		ValidArgsFunction: completion.ModelNames(desktopClient, 1),
 	}
 	c.Flags().BoolVar(&openai, "openai", false, "List model in an OpenAI format")
 	return c
+}
+
+func inpsectModel(args []string, openai bool, desktopClient *desktop.Client) (string, error) {
+	modelName := args[0]
+	if openai {
+		model, err := desktopClient.InspectOpenAI(modelName)
+		if err != nil {
+			err = handleClientError(err, "Failed to get model "+modelName)
+			return "", handleNotRunningError(err)
+		}
+		return model, nil
+	}
+	model, err := desktopClient.Inspect(modelName)
+	if err != nil {
+		err = handleClientError(err, "Failed to get model "+modelName)
+		return "", handleNotRunningError(err)
+	}
+	jsonModel, err := formatter.ToStandardJSON(model)
+	if err != nil {
+		return "", err
+	}
+	return jsonModel, nil
 }

--- a/commands/list.go
+++ b/commands/list.go
@@ -45,7 +45,7 @@ func listModels(openai bool, desktopClient *desktop.Client, quiet bool, jsonForm
 			err = handleClientError(err, "Failed to list models")
 			return "", handleNotRunningError(err)
 		}
-		return models, nil
+		return formatter.ToStandardJSON(models)
 	}
 	models, err := desktopClient.List()
 	if err != nil {
@@ -53,11 +53,7 @@ func listModels(openai bool, desktopClient *desktop.Client, quiet bool, jsonForm
 		return "", handleNotRunningError(err)
 	}
 	if jsonFormat {
-		jsonModels, err := formatter.ToStandardJSON(models)
-		if err != nil {
-			return "", err
-		}
-		return jsonModels, nil
+		return formatter.ToStandardJSON(models)
 	}
 	if quiet {
 		var modelIDs string

--- a/commands/run.go
+++ b/commands/run.go
@@ -33,7 +33,8 @@ func newRunCmd(desktopClient *desktop.Client) *cobra.Command {
 				}
 			}
 
-			if _, err := desktopClient.List(false, false, false, model); err != nil {
+			modelDetail, err := desktopClient.Inspect(model)
+			if err != nil {
 				if !errors.Is(err, desktop.ErrNotFound) {
 					return handleNotRunningError(handleClientError(err, "Failed to list models"))
 				}
@@ -41,6 +42,9 @@ func newRunCmd(desktopClient *desktop.Client) *cobra.Command {
 				if err := pullModel(cmd, desktopClient, model); err != nil {
 					return err
 				}
+			}
+			if model != modelDetail.Tags[0] {
+				model = modelDetail.Tags[0]
 			}
 
 			if prompt != "" {

--- a/desktop/api.go
+++ b/desktop/api.go
@@ -32,6 +32,18 @@ type OpenAIChatResponse struct {
 	} `json:"choices"`
 }
 
+type OpenAIModel struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
+
+type OpenAIModelList struct {
+	Object string         `json:"object"`
+	Data   []*OpenAIModel `json:"data"`
+}
+
 // TODO: To be replaced by the Model struct from pianta's common/pkg/inference/models/api.go.
 // (https://github.com/docker/pinata/pull/33331)
 type Format string

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -228,10 +228,11 @@ func (c *Client) Inspect(model string) (Model, error) {
 	if model != "" {
 		if !strings.Contains(strings.Trim(model, "/"), "/") {
 			// Do an extra API call to check if the model parameter isn't a model ID.
-			var err error
-			if model, err = c.fullModelID(model); err != nil {
+			modelId, err := c.fullModelID(model)
+			if err != nil {
 				return Model{}, fmt.Errorf("invalid model name: %s", model)
 			}
+			model = modelId
 		}
 	}
 	rawResponse, err := c.listRaw(fmt.Sprintf("%s/%s", inference.ModelsPrefix, model), model)

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -296,6 +296,22 @@ func (c *Client) Inspect(model string) (Model, error) {
 	return modelInspect, nil
 }
 
+func (c *Client) InspectOpenAI(model string) (string, error) {
+	modelsRoute := inference.InferencePrefix + "/v1/models"
+	if !strings.Contains(strings.Trim(model, "/"), "/") {
+		// Do an extra API call to check if the model parameter isn't a model ID.
+		var err error
+		if model, err = c.modelNameFromID(model); err != nil {
+			return "", fmt.Errorf("invalid model name: %s", model)
+		}
+	}
+	rawResponse, err := c.listRaw(fmt.Sprintf("%s/%s", modelsRoute, model), model)
+	if err != nil {
+		return "", err
+	}
+	return string(rawResponse), nil
+}
+
 func (c *Client) listRaw(route string, model string) ([]byte, error) {
 	resp, err := c.doRequest(http.MethodGet, route, nil)
 	if err != nil {


### PR DESCRIPTION
Added the capability to run a model from its ID
Splited `Client.List` function to apply separation of concerns:
 - List only return an array of Models
 - Add ListOpenAI to get an array of OpenAIModel
 - Introduce an Inspect function to get the detail of one Model
 - Add InspectOpenAI function to get the detail of one OpenAIModel
 - Remove the formatting from the Client and moved it the the CLI commands
 - Add a new install make task which build & link the binary at once