### PR TITLE
Handle Untagged Models

### DIFF
--- a/commands/list_test.go
+++ b/commands/list_test.go
@@ -1,0 +1,1 @@
+package commands

--- a/commands/list_test.go
+++ b/commands/list_test.go
@@ -1,1 +1,0 @@
-package commands

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -476,29 +476,33 @@ func prettyPrintModels(models []Model) string {
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 
 	for _, m := range models {
-		var tag string
-		if len(m.Tags) > 0 {
-			tag = m.Tags[0]
-		} else {
-			tag = "<none>"
-		}
-		if len(m.ID) < 19 {
-			fmt.Fprintf(os.Stderr, "invalid image ID for model: %v\n", m)
+		if len(m.Tags) == 0 {
+			appendRow(table, "<none>", m)
 			continue
 		}
-		table.Append([]string{
-			tag,
-			m.Config.Parameters,
-			m.Config.Quantization,
-			m.Config.Architecture,
-			m.ID[7:19],
-			units.HumanDuration(time.Since(time.Unix(m.Created, 0))) + " ago",
-			m.Config.Size,
-		})
+		for _, tag := range m.Tags {
+			appendRow(table, tag, m)
+		}
 	}
 
 	table.Render()
 	return buf.String()
+}
+
+func appendRow(table *tablewriter.Table, tag string, model Model) {
+	if len(model.ID) < 19 {
+		fmt.Fprintf(os.Stderr, "invalid image ID for model: %v\n", model)
+		return
+	}
+	table.Append([]string{
+		tag,
+		model.Config.Parameters,
+		model.Config.Quantization,
+		model.Config.Architecture,
+		model.ID[7:19],
+		units.HumanDuration(time.Since(time.Unix(model.Created, 0))) + " ago",
+		model.Config.Size,
+	})
 }
 
 func (c *Client) Tag(source, targetRepo, targetTag string) (string, error) {

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -495,7 +495,7 @@ func prettyPrintModels(models []Model) string {
 
 func appendRow(table *tablewriter.Table, tag string, model Model) {
 	if len(model.ID) < 19 {
-		fmt.Fprintf(os.Stderr, "invalid image ID for model: %v\n", model)
+		fmt.Fprintf(os.Stderr, "invalid model ID for model: %v\n", model)
 		return
 	}
 	table.Append([]string{

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -456,7 +456,7 @@ func prettyPrintModels(models []Model) string {
 	var buf bytes.Buffer
 	table := tablewriter.NewWriter(&buf)
 
-	table.SetHeader([]string{"MODEL", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "MODEL ID", "CREATED", "SIZE"})
+	table.SetHeader([]string{"MODEL NAME", "PARAMETERS", "QUANTIZATION", "ARCHITECTURE", "MODEL ID", "CREATED", "SIZE"})
 
 	table.SetBorder(false)
 	table.SetColumnSeparator("")
@@ -476,16 +476,18 @@ func prettyPrintModels(models []Model) string {
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 
 	for _, m := range models {
-		if len(m.Tags) == 0 {
-			fmt.Fprintf(os.Stderr, "no tags found for model: %v\n", m)
-			continue
+		var tag string
+		if len(m.Tags) > 0 {
+			tag = m.Tags[0]
+		} else {
+			tag = "<none>"
 		}
 		if len(m.ID) < 19 {
 			fmt.Fprintf(os.Stderr, "invalid image ID for model: %v\n", m)
 			continue
 		}
 		table.Append([]string{
-			m.Tags[0],
+			tag,
 			m.Config.Parameters,
 			m.Config.Quantization,
 			m.Config.Architecture,


### PR DESCRIPTION
### List

#### Display Multiple Tags
For models with multiple tags, `model list` displays one row per tag. This is important now that `model tag` allows users to apply extra tags to a model.
```
./model-cli list
MODEL NAME                                    PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED      SIZE
ai/smollm2                                    361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB
index.docker.io/emilycasey003/smollm2:latest  361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB
index.docker.io/emilycasey003/demo:latest     361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB
```
### Display Untagged Models
For models with zero tags `model list` displays "MODEL NAME" as `<none>`. This is important b/c repointing a tag with `model tag` or `model pull`ing a new version may leave a model without a tag reference.
```
./model-cli list
MODEL NAME                                    PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED      SIZE
ai/smollm2                                    361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB
index.docker.io/emilycasey003/smollm2:latest  361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB
emilycasey003/demo:latest                     361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB
<none>                                        183         Unknown         llama         8e29acb3019c  2 weeks ago  864 B
```

### Inspect
`model inspect` can display data for untagged models when given a full or shortened ID. (previously this panicked)
```
./model-cli inspect 8e29acb3019c
{
  "id": "sha256:8e29acb3019cd9bfb04b90b6a77b1bff4ab7abb9dc3efe2fba18729343d5e6d5",
  "tags": null,
  "created": 1743622285,
  "config": {
    "format": "gguf",
    "quantization": "Unknown",
    "parameters": "183",
    "architecture": "llama",
    "size": "864 B"
  }
}
```
```
./model-cli inspect sha256:8e29acb3019cd9bfb04b90b6a77b1bff4ab7abb9dc3efe2fba18729343d5e6d5
{
  "id": "sha256:8e29acb3019cd9bfb04b90b6a77b1bff4ab7abb9dc3efe2fba18729343d5e6d5",
  "tags": null,
  "created": 1743622285,
  "config": {
    "format": "gguf",
    "quantization": "Unknown",
    "parameters": "183",
    "architecture": "llama",
    "size": "864 B"
  }
}
```

### Remove
`model rm` can remove an untagged model by ID. This allows removal of untagged models. Previously this panicked
```
./model-cli rm 8e29acb3019c
Model sha256:8e29acb3019cd9bfb04b90b6a77b1bff4ab7abb9dc3efe2fba18729343d5e6d5 removed successfully
```
#### Known Issue - Removing tagged model by ID
`model rm <id>` reports successful removal of tagged model, but doesn't actually remove the model. The model must be untagged first.

### Run
`model run` can run an untagged model by ID.

