### PR TITLE
docker model rm --force

### DIFF
--- a/commands/rm.go
+++ b/commands/rm.go
@@ -9,6 +9,8 @@ import (
 )
 
 func newRemoveCmd(desktopClient *desktop.Client) *cobra.Command {
+	var force bool
+
 	c := &cobra.Command{
 		Use:   "rm [MODEL...]",
 		Short: "Remove models downloaded from Docker Hub",
@@ -23,7 +25,7 @@ func newRemoveCmd(desktopClient *desktop.Client) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			response, err := desktopClient.Remove(args)
+			response, err := desktopClient.Remove(args, force)
 			if response != "" {
 				cmd.Println(response)
 			}
@@ -35,5 +37,7 @@ func newRemoveCmd(desktopClient *desktop.Client) *cobra.Command {
 		},
 		ValidArgsFunction: completion.ModelNames(desktopClient, -1),
 	}
+
+	c.Flags().BoolVarP(&force, "force", "f", false, "Forcefully remove the model")
 	return c
 }

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -390,7 +391,7 @@ func (c *Client) Chat(model, prompt string) error {
 	return nil
 }
 
-func (c *Client) Remove(models []string) (string, error) {
+func (c *Client) Remove(models []string, force bool) (string, error) {
 	modelRemoved := ""
 	for _, model := range models {
 		// Check if not a model ID passed as parameter.
@@ -400,7 +401,13 @@ func (c *Client) Remove(models []string) (string, error) {
 			}
 		}
 
-		removePath := inference.ModelsPrefix + "/" + model
+		// Construct the URL with query parameters
+		removePath := fmt.Sprintf("%s/%s?force=%s",
+			inference.ModelsPrefix,
+			model,
+			strconv.FormatBool(force),
+		)
+
 		resp, err := c.doRequest(http.MethodDelete, removePath, nil)
 		if err != nil {
 			return modelRemoved, c.handleQueryError(err, removePath)


### PR DESCRIPTION
Allow forced removal of models with `docker model rm --force`.

Example:
```
./model-cli list
MODEL NAME                          PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED      SIZE
ai/smollm2                          361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB
index.docker.io/foo/smollm2:latest  361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 weeks ago  256.35 MiB

./model-cli rm 354bf30d0aa3
Error: Failed to remove model: removing sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 failed with status 409 Conflict: unable to delete "sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9" (must be forced) due to multiple tag references: resource conflict

Usage:
  model rm [MODEL...] [flags]

Flags:
  -f, --force   Forcefully remove the model
  -h, --help    help for rm

Failed to remove model: removing sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 failed with status 409 Conflict: unable to delete "sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9" (must be forced) due to multiple tag references: resource conflict

./model-cli rm --force 354bf30d0aa3
Model sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 removed successfully

./model-cli list
MODEL NAME  PARAMETERS  QUANTIZATION  ARCHITECTURE  MODEL ID  CREATED  SIZE
```

For details see https://github.com/docker/model-distribution/pull/66