### PR TITLE
run: Ensure model name/tag only if it's not pulled

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -42,8 +42,7 @@ func newRunCmd(desktopClient *desktop.Client) *cobra.Command {
 				if err := pullModel(cmd, desktopClient, model); err != nil {
 					return err
 				}
-			}
-			if model != modelDetail.Tags[0] {
+			} else if model != modelDetail.Tags[0] {
 				model = modelDetail.Tags[0]
 			}
 


### PR DESCRIPTION
Running a model which has to be pulled will result in a panic.
Without this patch:
```
$ docker model run ghcr.io/ilopezluna/smollm2 'hi'
Unable to find model 'ghcr.io/ilopezluna/smollm2' locally. Pulling from the server.
Downloaded: 83.75 MB
Model pulled successfully
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/docker/model-cli/commands.newRunCmd.func1(0x140000ffb08, {0x140000d67c0?, 0x0?, 0xb7117dd000000000?})
	/Users/doringeman/workspace/model-cli/commands/run.go:46 +0x61c
```