### PR TITLE
User agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ release:
 		exit 1; \
 	fi
 	@echo "Building release version '$(VERSION)'..."
-	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/commands.Version=$(VERSION)" -o dist/darwin-arm64/$(PLUGIN_NAME) .
-	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X github.com/docker/model-cli/commands.Version=$(VERSION)" -o dist/windows-amd64/$(PLUGIN_NAME).exe .
-	GOOS=windows GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/commands.Version=$(VERSION)" -o dist/windows-arm64/$(PLUGIN_NAME).exe .
+	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/darwin-arm64/$(PLUGIN_NAME) .
+	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-amd64/$(PLUGIN_NAME).exe .
+	GOOS=windows GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-arm64/$(PLUGIN_NAME).exe .
 	@echo "Release build complete: $(PLUGIN_NAME) version '$(VERSION)'"
 
 mock:

--- a/commands/version.go
+++ b/commands/version.go
@@ -2,17 +2,16 @@ package commands
 
 import (
 	"github.com/docker/model-cli/commands/completion"
+	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
 )
-
-var Version = "dev"
 
 func newVersionCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "version",
 		Short: "Show the Docker Model Runner version",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf("Docker Model Runner version %s\n", Version)
+			cmd.Printf("Docker Model Runner version %s\n", desktop.Version)
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -461,6 +461,7 @@ func (c *Client) doRequest(method, path string, body io.Reader) (*http.Response,
 		req.Header.Set("Content-Type", "application/json")
 	}
 
+	req.Header.Set("User-Agent", "docker-model-cli/"+Version)
 	resp, err := c.dockerClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/desktop/version.go
+++ b/desktop/version.go
@@ -1,0 +1,3 @@
+package desktop
+
+var Version = "dev"

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/model-cli/commands"
+	"github.com/docker/model-cli/desktop"
 )
 
 func main() {
@@ -32,6 +33,6 @@ func run() error {
 	return plugin.RunPlugin(cli, rootCmd, manager.Metadata{
 		SchemaVersion: "0.1.0",
 		Vendor:        "Docker Inc.",
-		Version:       commands.Version,
+		Version:       desktop.Version,
 	})
 }


### PR DESCRIPTION
```
$ make release VERSION=hi-docker-version-test
$ ./dist/darwin-arm64/docker-model version
Docker Model Runner version hi-docker-version-test
```

I also tested it locally with Docker Desktop.