### PR TITLE
Add Linux builds to release for Docker CE support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ release:
 	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/darwin-arm64/$(PLUGIN_NAME) .
 	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-amd64/$(PLUGIN_NAME).exe .
 	GOOS=windows GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-arm64/$(PLUGIN_NAME).exe .
+	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/linux-amd64/$(PLUGIN_NAME) .
+	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/linux-arm64/$(PLUGIN_NAME) .
 	@echo "Release build complete: $(PLUGIN_NAME) version '$(VERSION)'"
 
 mock:


### PR DESCRIPTION
We'll probably use Aptitude / RPM packages once we publish for release, but for C0 let's include these binaries in the Docker Desktop module image and grab them from there.