### PR TITLE
Use -trimpath and disable CGo on Linux for release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ release:
 		exit 1; \
 	fi
 	@echo "Building release version '$(VERSION)'..."
-	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/darwin-arm64/$(PLUGIN_NAME) .
-	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-amd64/$(PLUGIN_NAME).exe .
-	GOOS=windows GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-arm64/$(PLUGIN_NAME).exe .
-	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/linux-amd64/$(PLUGIN_NAME) .
-	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/linux-arm64/$(PLUGIN_NAME) .
+	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/darwin-arm64/$(PLUGIN_NAME) .
+	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-amd64/$(PLUGIN_NAME).exe .
+	GOOS=windows GOARCH=arm64 go build -trimpath -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/windows-arm64/$(PLUGIN_NAME).exe .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/linux-amd64/$(PLUGIN_NAME) .
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/linux-arm64/$(PLUGIN_NAME) .
 	@echo "Release build complete: $(PLUGIN_NAME) version '$(VERSION)'"
 
 ce-release:
@@ -49,7 +49,7 @@ ce-release:
 		echo "Warning: This release target is designed for Linux"; \
 	fi
 	@echo "Building local release version '$(VERSION)'..."
-	GOOS=linux go build -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/$(PLUGIN_NAME) .
+	CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w -X github.com/docker/model-cli/desktop.Version=$(VERSION)" -o dist/$(PLUGIN_NAME) .
 	@echo "Local release build complete: $(PLUGIN_NAME) version '$(VERSION)'"
 
 mock:


### PR DESCRIPTION
We don't want CGo for Linux release binaries because we don't want a glibc dependency.

We can also make slightly more consistent binaries by using `-trimpath`.