### PR TITLE
Fix unit tests by setting the User-Agent

### DIFF
--- a/commands/status_test.go
+++ b/commands/status_test.go
@@ -81,11 +81,13 @@ func TestStatus(t *testing.T) {
 
 			req, err := http.NewRequest(http.MethodGet, desktop.URL(inference.ModelsPrefix, ""), nil)
 			require.NoError(t, err)
+			req.Header.Set("User-Agent", "docker-model-cli/"+desktop.Version)
 			client.EXPECT().Do(req).Return(test.doResponse, test.doErr)
 
 			if test.doResponse != nil && test.doResponse.StatusCode == http.StatusOK {
 				req, err = http.NewRequest(http.MethodGet, desktop.URL(inference.InferencePrefix+"/status", ""), nil)
 				require.NoError(t, err)
+				req.Header.Set("User-Agent", "docker-model-cli/"+desktop.Version)
 				client.EXPECT().Do(req).Return(&http.Response{Body: mockBody}, test.doErr)
 			}
 


### PR DESCRIPTION
Fix unit tests by setting the User-Agent.
They have been broken by https://github.com/docker/model-cli/commit/d898b974995d1dd3fe96d5b781c2ec7156287ecd.

```
make mock && make unit-tests
```