### PR TITLE
cli: fix autocompletion to work with context detection

### DIFF
--- a/commands/completion/functions.go
+++ b/commands/completion/functions.go
@@ -10,12 +10,17 @@ func NoComplete(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCo
 }
 
 // ModelNames offers completion for models present within the local store.
-func ModelNames(desktopClient *desktop.Client, limit int) cobra.CompletionFunc {
+func ModelNames(desktopClient func() *desktop.Client, limit int) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// HACK: Invoke rootCmd's PersistentPreRunE, which is needed for context
+		// detection and client initialization. This function isn't invoked
+		// automatically on autocompletion paths.
+		cmd.Parent().PersistentPreRunE(cmd, args)
+
 		if limit > 0 && len(args) >= limit {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		models, err := desktopClient.List()
+		models, err := desktopClient().List()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -34,7 +34,7 @@ func newInspectCmd() *cobra.Command {
 			cmd.Print(inspectedModel)
 			return nil
 		},
-		ValidArgsFunction: completion.ModelNames(desktopClient, 1),
+		ValidArgsFunction: completion.ModelNames(getDesktopClient, 1),
 	}
 	c.Flags().BoolVar(&openai, "openai", false, "List model in an OpenAI format")
 	return c

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -37,7 +37,7 @@ func newRemoveCmd() *cobra.Command {
 			}
 			return nil
 		},
-		ValidArgsFunction: completion.ModelNames(desktopClient, -1),
+		ValidArgsFunction: completion.ModelNames(getDesktopClient, -1),
 	}
 
 	c.Flags().BoolVarP(&force, "force", "f", false, "Forcefully remove the model")

--- a/commands/root.go
+++ b/commands/root.go
@@ -13,13 +13,31 @@ import (
 // dockerCLI is the Docker CLI environment associated with the command.
 var dockerCLI *command.DockerCli
 
+// getDockerCLI is an accessor for dockerCLI that can be passed to other
+// packages.
+func getDockerCLI() *command.DockerCli {
+	return dockerCLI
+}
+
 // modelRunner is the model runner context. It is initialized by the root
 // command's PersistentPreRunE.
 var modelRunner *desktop.ModelRunnerContext
 
+// getModelRunner is an accessor for modelRunner that can be passed to other
+// packages.
+func getModelRunner() *desktop.ModelRunnerContext {
+	return modelRunner
+}
+
 // desktopClient is the model runner client. It is initialized by the root
 // command's PersistentPreRunE.
 var desktopClient *desktop.Client
+
+// getDesktopClient is an accessor for desktopClient that can be passed to other
+// packages.
+func getDesktopClient() *desktop.Client {
+	return desktopClient
+}
 
 func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 	// If we're running in standalone mode, then we're responsible for

--- a/commands/run.go
+++ b/commands/run.go
@@ -89,7 +89,7 @@ func newRunCmd() *cobra.Command {
 			}
 			return nil
 		},
-		ValidArgsFunction: completion.ModelNames(desktopClient, 1),
+		ValidArgsFunction: completion.ModelNames(getDesktopClient, 1),
 	}
 	c.Args = func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {


### PR DESCRIPTION
The autocomplete didn't function after context detection because (1) it had a stale (`nil`) client reference and (2) CLI initialization wasn't occurring on the autocomplete path.