### PR TITLE
cloud: Move Cloud install logic into Model CLI and add GPU detection

### DIFF
--- a/commands/install-runner.go
+++ b/commands/install-runner.go
@@ -14,13 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// noopPrinter is used to silence auto-install progress if desired.
-type noopPrinter struct{}
-
-func (*noopPrinter) Printf(format string, args ...any) {}
-
-func (*noopPrinter) Println(args ...any) {}
-
 const (
 	// installWaitTries controls how many times the automatic installation will
 	// try to reach the model runner while waiting for it to be ready.
@@ -68,7 +61,7 @@ func ensureStandaloneRunnerAvailable(ctx context.Context, printer standalone.Sta
 
 	// Ensure that the output printer is non-nil.
 	if printer == nil {
-		printer = &noopPrinter{}
+		printer = standalone.NoopPrinter()
 	}
 
 	// Create a Docker client for the active context.

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -33,7 +33,10 @@ func newLogsCmd() *cobra.Command {
 
 			// If we're running in standalone mode, then print the container
 			// logs.
-			if modelRunner.EngineKind() == desktop.ModelRunnerEngineKindMoby {
+			engineKind := modelRunner.EngineKind()
+			useStandaloneLogs := engineKind == desktop.ModelRunnerEngineKindMoby ||
+				engineKind == desktop.ModelRunnerEngineKindCloud
+			if useStandaloneLogs {
 				dockerClient, err := desktop.DockerClientForContext(dockerCLI, dockerCLI.CurrentContext())
 				if err != nil {
 					return fmt.Errorf("failed to create Docker client: %w", err)

--- a/commands/uninstall-runner.go
+++ b/commands/uninstall-runner.go
@@ -26,9 +26,6 @@ func newUninstallRunner() *cobra.Command {
 			} else if kind == desktop.ModelRunnerEngineKindMobyManual {
 				cmd.Println("Standalone uninstallation not supported with MODEL_RUNNER_HOST set")
 				return nil
-			} else if kind == desktop.ModelRunnerEngineKindCloud {
-				cmd.Println("Standalone uninstallation not supported with Docker Cloud")
-				return nil
 			}
 
 			// Create a Docker client for the active context.

--- a/commands/uninstall-runner.go
+++ b/commands/uninstall-runner.go
@@ -35,7 +35,7 @@ func newUninstallRunner() *cobra.Command {
 			}
 
 			// Remove any model runner containers.
-			if err := standalone.PruneControllerContainers(cmd.Context(), dockerClient, cmd); err != nil {
+			if err := standalone.PruneControllerContainers(cmd.Context(), dockerClient, false, cmd); err != nil {
 				return fmt.Errorf("unable to remove model runner container(s): %w", err)
 			}
 

--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -1,0 +1,29 @@
+package gpu
+
+import (
+	"context"
+
+	"github.com/docker/docker/client"
+)
+
+// GPUSupport encodes the GPU support available on a Docker engine.
+type GPUSupport uint8
+
+const (
+	// GPUSupportNone indicates no detectable GPU support.
+	GPUSupportNone GPUSupport = iota
+	// GPUSupportCUDA indicates CUDA GPU support.
+	GPUSupportCUDA
+)
+
+// ProbeGPUSupport determines whether or not the Docker engine has GPU support.
+func ProbeGPUSupport(ctx context.Context, dockerClient *client.Client) (GPUSupport, error) {
+	info, err := dockerClient.Info(ctx)
+	if err != nil {
+		return GPUSupportNone, err
+	}
+	if _, hasNvidia := info.Runtimes["nvidia"]; hasNvidia {
+		return GPUSupportCUDA, nil
+	}
+	return GPUSupportNone, nil
+}

--- a/pkg/standalone/labels.go
+++ b/pkg/standalone/labels.go
@@ -1,6 +1,16 @@
 package standalone
 
 const (
+	// labelDesktopService is the label used to identify a container or image as
+	// a Docker Desktop service component. This causes the object to be hidden
+	// from listing requests (unless --filter label=com.docker.desktop.service
+	// is specified). This applies to both Docker Desktop and Docker Cloud.
+	labelDesktopService = "com.docker.desktop.service"
+
+	// serviceModelRunner is the service label value used to identify model
+	// runner components.
+	serviceModelRunner = "model-runner"
+
 	// labelRole is the label used to identify a Docker object's role in the
 	// standalone model runner infrastructure.
 	labelRole = "com.docker.model-runner.role"

--- a/pkg/standalone/status.go
+++ b/pkg/standalone/status.go
@@ -7,3 +7,17 @@ type StatusPrinter interface {
 	// Println should perform line-based printing.
 	Println(args ...any)
 }
+
+// noopPrinter is used to silence auto-install progress if desired.
+type noopPrinter struct{}
+
+// Printf implements StatusPrinter.Printf.
+func (*noopPrinter) Printf(format string, args ...any) {}
+
+// Println implements StatusPrinter.Println.
+func (*noopPrinter) Println(args ...any) {}
+
+// NoopPrinter returns a StatusPrinter that does nothing.
+func NoopPrinter() StatusPrinter {
+	return &noopPrinter{}
+}

--- a/pkg/standalone/volumes.go
+++ b/pkg/standalone/volumes.go
@@ -37,7 +37,8 @@ func EnsureModelStorageVolume(ctx context.Context, dockerClient *client.Client, 
 	volume, err := dockerClient.VolumeCreate(ctx, volume.CreateOptions{
 		Name: modelStorageVolumeName,
 		Labels: map[string]string{
-			labelRole: roleModelStorage,
+			labelDesktopService: serviceModelRunner,
+			labelRole:           roleModelStorage,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
After prototyping the middleware-based Cloud approach, it's become clear
that there's so much overlap with the Docker CE support that we should
just move the installation into the Model CLI. We now no longer need
middleware in the Cloud CLI.

This required adding GPU detection, which is a little more flexible now
and also applies to Docker CE.  It also needed some more refined network / port
binding and readiness detection.

This does put us in the position of having a Cloud engine's runner's TCP
port exposed locally, but that was the case already for Cloud due to TCC
implmentation details. We still have time to refine this transport.

Overall, this keeps the logic much simpler and doesn't require
duplication in the Cloud CLI codebase.