### PR TITLE
standalone: use different default port for Cloud installs

### DIFF
--- a/commands/compose.go
+++ b/commands/compose.go
@@ -51,9 +51,12 @@ func newUpCommand() *cobra.Command {
 				_ = setenv("URL", "http://model-runner.docker.internal/engines/v1/")
 			} else if kind == desktop.ModelRunnerEngineKindMobyManual {
 				_ = setenv("URL", modelRunner.URL("/engines/v1/"))
-			} else if kind == desktop.ModelRunnerEngineKindMoby || kind == desktop.ModelRunnerEngineKindCloud {
-				// TODO: Find a more robust solution in Moby-like environments.
-				_ = setenv("URL", "http://host.docker.internal:"+strconv.Itoa(standalone.DefaultControllerPort)+"/engines/v1/")
+			} else if kind == desktop.ModelRunnerEngineKindMoby {
+				// TODO: Use more robust detection in Moby-like environments.
+				_ = setenv("URL", "http://host.docker.internal:"+strconv.Itoa(standalone.DefaultControllerPortMoby)+"/engines/v1/")
+			} else if kind == desktop.ModelRunnerEngineKindCloud {
+				// TODO: Use more robust detection in Cloud environments.
+				_ = setenv("URL", "http://host.docker.internal:"+strconv.Itoa(standalone.DefaultControllerPortCloud)+"/engines/v1/")
 			}
 			return nil
 		},

--- a/desktop/context.go
+++ b/desktop/context.go
@@ -159,14 +159,16 @@ func DetectContext(cli *command.DockerCli) (*ModelRunnerContext, error) {
 
 	// Compute the URL prefix based on the associated engine kind.
 	var rawURLPrefix string
-	if kind == ModelRunnerEngineKindMoby || kind == ModelRunnerEngineKindCloud {
-		rawURLPrefix = "http://localhost:" + strconv.Itoa(int(standalone.DefaultControllerPort))
+	if kind == ModelRunnerEngineKindMoby {
+		rawURLPrefix = "http://localhost:" + strconv.Itoa(standalone.DefaultControllerPortMoby)
+	} else if kind == ModelRunnerEngineKindCloud {
+		rawURLPrefix = "http://localhost:" + strconv.Itoa(standalone.DefaultControllerPortCloud)
 	} else if kind == ModelRunnerEngineKindMobyManual {
 		rawURLPrefix = modelRunnerHost
 	} else { // ModelRunnerEngineKindDesktop
 		rawURLPrefix = "http://localhost" + inference.ExperimentalEndpointsPrefix
 		if treatDesktopAsMoby {
-			rawURLPrefix = "http://localhost:" + strconv.Itoa(int(standalone.DefaultControllerPort))
+			rawURLPrefix = "http://localhost:" + strconv.Itoa(standalone.DefaultControllerPortMoby)
 		}
 	}
 	urlPrefix, err := url.Parse(rawURLPrefix)

--- a/pkg/standalone/ports.go
+++ b/pkg/standalone/ports.go
@@ -1,5 +1,10 @@
 package standalone
 
-// DefaultControllerPort is the default TCP port on which the standalone
-// controller will listen for requests.
-const DefaultControllerPort = 12434
+const (
+	// DefaultControllerPortMoby is the default TCP port on which the standalone
+	// controller will listen for requests in Moby environments.
+	DefaultControllerPortMoby = 12434
+	// DefaultControllerPortCloud is the default TCP port on which the
+	// standalone controller will listen for requests in Moby environments.
+	DefaultControllerPortCloud = 12435
+)


### PR DESCRIPTION
We want to avoid clashes with Docker Desktop's default host-side port, so we'll use `12435` as the default on Cloud installs.  There's a little bit of internal ugliness, but it should be mostly invisible to users.