### PR TITLE
Add `docker model unload`

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -110,6 +110,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newUninstallRunner(),
 		newPSCmd(),
 		newDFCmd(),
+		newUnloadCmd(),
 	)
 	return rootCmd
 }

--- a/commands/unload.go
+++ b/commands/unload.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/model-cli/commands/completion"
+	"github.com/docker/model-cli/desktop"
+	"github.com/spf13/cobra"
+)
+
+func newUnloadCmd() *cobra.Command {
+	var all bool
+	var backend string
+
+	cmdArgs := "(MODEL [--backend BACKEND] | --all)"
+	c := &cobra.Command{
+		Use:   "unload " + cmdArgs,
+		Short: "Unload running models",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			model := args[0]
+			unloadResp, err := desktopClient.Unload(desktop.UnloadRequest{All: all, Backend: backend, Model: model})
+			if err != nil {
+				err = handleClientError(err, "Failed to unload models")
+				return handleNotRunningError(err)
+			}
+			unloaded := unloadResp.UnloadedRunners
+			if unloaded == 0 {
+				if all {
+					cmd.Println("No models are running.")
+				} else {
+					cmd.Println("No such model(s) running.")
+				}
+			} else {
+				cmd.Printf("Unloaded %d model(s).\n", unloaded)
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.NoComplete,
+	}
+	c.Args = func(cmd *cobra.Command, args []string) error {
+		if all {
+			if len(args) > 0 {
+				return fmt.Errorf(
+					"'docker model unload' does not take MODEL when --all is specified.\n\n" +
+						"Usage:  docker model unload " + cmdArgs + "\n\n" +
+						"See 'docker model unload --help' for more information.",
+				)
+			}
+			return nil
+		}
+		if len(args) < 1 {
+			return fmt.Errorf(
+				"'docker model unload' requires MODEL unless --all is specified.\n\n" +
+					"Usage:  docker model unload " + cmdArgs + "\n\n" +
+					"See 'docker model unload --help' for more information.",
+			)
+		}
+		if len(args) > 1 {
+			return fmt.Errorf("too many arguments, expected " + cmdArgs)
+		}
+		return nil
+	}
+	c.Flags().BoolVar(&all, "all", false, "Unload all running models")
+	c.Flags().StringVar(&backend, "backend", "", "Optional backend to target")
+	return c
+}


### PR DESCRIPTION
On top of https://github.com/docker/model-cli/pull/64.

You can launch https://github.com/docker/model-runner/pull/46 using `make docker-run`.

```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model run ai/smollm2 hi
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model unload --all
Unloaded 1 model(s).
$ # run again
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model unload ai/smollm2
Unloaded 1 model(s).
$ # run again
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model unload --backend llama.cpp ai/smollm2
Unloaded 1 model(s).
```