### PR TITLE
Add `docker model prune`

### DIFF
--- a/commands/df.go
+++ b/commands/df.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"bytes"
+
+	"github.com/docker/go-units"
+	"github.com/docker/model-cli/commands/completion"
+	"github.com/docker/model-cli/desktop"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+func newDFCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "df",
+		Short: "Show Docker Model Runner disk usage",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			df, err := desktopClient.DF()
+			if err != nil {
+				err = handleClientError(err, "Failed to list running models")
+				return handleNotRunningError(err)
+			}
+			cmd.Print(diskUsageTable(df))
+			return nil
+		},
+		ValidArgsFunction: completion.NoComplete,
+	}
+	return c
+}
+
+func diskUsageTable(df desktop.DiskUsage) string {
+	var buf bytes.Buffer
+	table := tablewriter.NewWriter(&buf)
+
+	table.SetHeader([]string{"TYPE", "SIZE"})
+
+	table.SetBorder(false)
+	table.SetColumnSeparator("")
+	table.SetHeaderLine(false)
+	table.SetTablePadding("  ")
+	table.SetNoWhiteSpace(true)
+
+	table.SetColumnAlignment([]int{
+		tablewriter.ALIGN_LEFT, // TYPE
+		tablewriter.ALIGN_LEFT, // SIZE
+	})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+
+	table.Append([]string{"Models", units.HumanSize(df.ModelsDiskUsage)})
+	if df.DefaultBackendDiskUsage != 0 {
+		table.Append([]string{"Inference engine", units.HumanSize(df.DefaultBackendDiskUsage)})
+	}
+
+	table.Render()
+	return buf.String()
+}

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/model-cli/commands/completion"
+	"github.com/docker/model-cli/desktop"
+	"github.com/spf13/cobra"
+)
+
+func newPruneCmd() *cobra.Command {
+	var force bool
+
+	c := &cobra.Command{
+		Use:   "prune [OPTIONS]",
+		Short: "Remove all models",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !force {
+				cmd.Println("WARNING! This will remove the entire models directory.")
+				cmd.Print("Are you sure you want to continue? [y/N] ")
+
+				var input string
+				_, err := fmt.Scanln(&input)
+				if err != nil && err.Error() != "unexpected newline" {
+					return err
+				}
+
+				if input != "y" && input != "Y" {
+					cmd.Println("Operation cancelled.")
+					return nil
+				}
+			}
+			_, err := desktopClient.Unload(desktop.UnloadRequest{All: true})
+			if err != nil {
+				err = handleClientError(err, "Failed to unload models")
+				return handleNotRunningError(err)
+			}
+			if err := desktopClient.Prune(); err != nil {
+				err = handleClientError(err, "Failed to prune")
+				return handleNotRunningError(err)
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.NoComplete,
+	}
+
+	c.Flags().BoolVarP(&force, "force", "f", false, "Forcefully remove all models")
+	return c
+}

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/docker/go-units"
+	"github.com/docker/model-cli/commands/completion"
+	"github.com/docker/model-cli/desktop"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+func newPSCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "ps",
+		Short: "List running models",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ps, err := desktopClient.PS()
+			if err != nil {
+				err = handleClientError(err, "Failed to list running models")
+				return handleNotRunningError(err)
+			}
+			cmd.Print(psTable(ps))
+			return nil
+		},
+		ValidArgsFunction: completion.NoComplete,
+	}
+	return c
+}
+
+func psTable(ps []desktop.BackendStatus) string {
+	var buf bytes.Buffer
+	table := tablewriter.NewWriter(&buf)
+
+	table.SetHeader([]string{"MODEL NAME", "BACKEND", "MODE", "LAST USED"})
+
+	table.SetBorder(false)
+	table.SetColumnSeparator("")
+	table.SetHeaderLine(false)
+	table.SetTablePadding("  ")
+	table.SetNoWhiteSpace(true)
+
+	table.SetColumnAlignment([]int{
+		tablewriter.ALIGN_LEFT, // MODEL
+		tablewriter.ALIGN_LEFT, // BACKEND
+		tablewriter.ALIGN_LEFT, // MODE
+		tablewriter.ALIGN_LEFT, // LAST USED
+	})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+
+	for _, status := range ps {
+		table.Append([]string{
+			status.ModelName,
+			status.BackendName,
+			status.Mode,
+			units.HumanDuration(time.Since(status.LastUsed)) + " ago",
+		})
+	}
+
+	table.Render()
+	return buf.String()
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -108,6 +108,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newUninstallRunner(),
 		newPSCmd(),
 		newDFCmd(),
+		newUnloadCmd(),
 	)
 	return rootCmd
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -107,6 +107,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newInstallRunner(),
 		newUninstallRunner(),
 		newPSCmd(),
+		newDFCmd(),
 	)
 	return rootCmd
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -106,6 +106,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newTagCmd(),
 		newInstallRunner(),
 		newUninstallRunner(),
+		newPSCmd(),
 	)
 	return rootCmd
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -109,6 +109,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newPSCmd(),
 		newDFCmd(),
 		newUnloadCmd(),
+		newPruneCmd(),
 	)
 	return rootCmd
 }

--- a/commands/unload.go
+++ b/commands/unload.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/model-cli/commands/completion"
+	"github.com/docker/model-cli/desktop"
+	"github.com/spf13/cobra"
+)
+
+func newUnloadCmd() *cobra.Command {
+	var all bool
+	var backend string
+
+	cmdArgs := "(MODEL [--backend BACKEND] | --all)"
+	c := &cobra.Command{
+		Use:   "unload " + cmdArgs,
+		Short: "Unload running models",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			model := args[0]
+			unloadResp, err := desktopClient.Unload(desktop.UnloadRequest{All: all, Backend: backend, Model: model})
+			if err != nil {
+				err = handleClientError(err, "Failed to unload models")
+				return handleNotRunningError(err)
+			}
+			unloaded := unloadResp.UnloadedRunners
+			if unloaded == 0 {
+				if all {
+					cmd.Println("No models are running.")
+				} else {
+					cmd.Println("No such model(s) running.")
+				}
+			} else {
+				cmd.Printf("Unloaded %d model(s).\n", unloaded)
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.NoComplete,
+	}
+	c.Args = func(cmd *cobra.Command, args []string) error {
+		if all {
+			if len(args) > 0 {
+				return fmt.Errorf(
+					"'docker model unload' does not take MODEL when --all is specified.\n\n" +
+						"Usage:  docker model unload " + cmdArgs + "\n\n" +
+						"See 'docker model unload --help' for more information.",
+				)
+			}
+			return nil
+		}
+		if len(args) < 1 {
+			return fmt.Errorf(
+				"'docker model unload' requires MODEL unless --all is specified.\n\n" +
+					"Usage:  docker model unload " + cmdArgs + "\n\n" +
+					"See 'docker model unload --help' for more information.",
+			)
+		}
+		if len(args) > 1 {
+			return fmt.Errorf("too many arguments, expected " + cmdArgs)
+		}
+		return nil
+	}
+	c.Flags().BoolVar(&all, "all", false, "Unload all running models")
+	c.Flags().StringVar(&backend, "backend", "", "Optional backend to target")
+	return c
+}

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -542,6 +542,22 @@ func (c *Client) Unload(req UnloadRequest) (UnloadResponse, error) {
 	return unloadResp, nil
 }
 
+func (c *Client) Prune() error {
+	prunePath := inference.ModelsPrefix + "/prune"
+	resp, err := c.doRequest(http.MethodDelete, prunePath, nil)
+	if err != nil {
+		return c.handleQueryError(err, prunePath)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("pruning failed with status %s: %s", resp.Status, string(body))
+	}
+
+	return nil
+}
+
 // doRequest is a helper function that performs HTTP requests and handles 503 responses
 func (c *Client) doRequest(method, path string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(method, c.modelRunner.URL(path), body)


### PR DESCRIPTION
On top of https://github.com/docker/model-cli/pull/65.

You can launch https://github.com/docker/model-runner/pull/47 using `make docker-run`.

```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model pull ghcr.io/ilopezluna/smollm2
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model ls
MODEL NAME                  PARAMETERS  QUANTIZATION  ARCHITECTURE  MODEL ID      CREATED      SIZE
ghcr.io/ilopezluna/smollm2  134.52 M    Q2_K          llama         425de603d029  6 weeks ago  82.41 MiB
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model prune
WARNING! This will remove the entire models directory.
Are you sure you want to continue? [y/N] y
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model ls
MODEL NAME  PARAMETERS  QUANTIZATION  ARCHITECTURE  MODEL ID  CREATED  SIZE
```