### PR TITLE
ci: fix missing pull_request event

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,7 @@ on:
       - 'v[0-9]*'
     tags:
       - 'v*'
+  pull_request:
 
 jobs:
   prepare:


### PR DESCRIPTION
relates to https://github.com/docker/model-cli/actions/runs/15166427237/job/42645360533#step:3:421

Forgot to add `pull_request` event in validate workflow.