### PR TITLE
Use int64 to represent byte sizes

### DIFF
--- a/commands/df.go
+++ b/commands/df.go
@@ -46,9 +46,9 @@ func diskUsageTable(df desktop.DiskUsage) string {
 	})
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 
-	table.Append([]string{"Models", units.HumanSize(df.ModelsDiskUsage)})
+	table.Append([]string{"Models", units.HumanSize(float64(df.ModelsDiskUsage))})
 	if df.DefaultBackendDiskUsage != 0 {
-		table.Append([]string{"Inference engine", units.HumanSize(df.DefaultBackendDiskUsage)})
+		table.Append([]string{"Inference engine", units.HumanSize(float64(df.DefaultBackendDiskUsage))})
 	}
 
 	table.Render()

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -474,8 +474,8 @@ func (c *Client) PS() ([]BackendStatus, error) {
 
 // DiskUsage to be imported from docker/model-runner when https://github.com/docker/model-runner/pull/45 is merged.
 type DiskUsage struct {
-	ModelsDiskUsage         float64 `json:"models_disk_usage"`
-	DefaultBackendDiskUsage float64 `json:"default_backend_disk_usage"`
+	ModelsDiskUsage         int64 `json:"models_disk_usage"`
+	DefaultBackendDiskUsage int64 `json:"default_backend_disk_usage"`
 }
 
 func (c *Client) DF() (DiskUsage, error) {


### PR DESCRIPTION
Adapt to https://github.com/docker/model-runner/pull/57