### PR TITLE
install-runner: Document both default ports for Moby and Cloud

### DIFF
--- a/commands/install-runner.go
+++ b/commands/install-runner.go
@@ -130,6 +130,12 @@ func newInstallRunner() *cobra.Command {
 				return nil
 			}
 
+			if port == 0 {
+				// Use "0" as a sentinel default flag value so it's not displayed automatically.
+				// The default values are written in the usage string.
+				// Hence, the user currently won't be able to set the port to 0 in order to get a random available port.
+				port = standalone.DefaultControllerPortMoby
+			}
 			// HACK: If we're in a Cloud context, then we need to use a
 			// different default port because it conflicts with Docker Desktop's
 			// default model runner host-side port. Unfortunately we can't make
@@ -193,8 +199,8 @@ func newInstallRunner() *cobra.Command {
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}
-	c.Flags().Uint16Var(&port, "port", standalone.DefaultControllerPortMoby,
-		"Docker container port for Docker Model Runner")
+	c.Flags().Uint16Var(&port, "port", 0,
+		"Docker container port for Docker Model Runner (default: 12434 for Docker CE, 12435 for Cloud mode)")
 	c.Flags().StringVar(&gpuMode, "gpu", "auto", "Specify GPU support (none|auto|cuda)")
 	c.Flags().BoolVar(&doNotTrack, "do-not-track", false, "Do not track models usage in Docker Model Runner")
 	return c

--- a/docs/reference/docker_model_install-runner.yaml
+++ b/docs/reference/docker_model_install-runner.yaml
@@ -28,8 +28,9 @@ options:
       swarm: false
     - option: port
       value_type: uint16
-      default_value: "12434"
-      description: Docker container port for Docker Model Runner
+      default_value: "0"
+      description: |
+        Docker container port for Docker Model Runner (default: 12434 for Docker CE, 12435 for Cloud mode)
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/reference/model_install-runner.md
+++ b/docs/reference/model_install-runner.md
@@ -5,11 +5,11 @@ Install Docker Model Runner (Docker Engine only)
 
 ### Options
 
-| Name             | Type     | Default | Description                                      |
-|:-----------------|:---------|:--------|:-------------------------------------------------|
-| `--do-not-track` | `bool`   |         | Do not track models usage in Docker Model Runner |
-| `--gpu`          | `string` | `auto`  | Specify GPU support (none\|auto\|cuda)           |
-| `--port`         | `uint16` | `12434` | Docker container port for Docker Model Runner    |
+| Name             | Type     | Default | Description                                                                                        |
+|:-----------------|:---------|:--------|:---------------------------------------------------------------------------------------------------|
+| `--do-not-track` | `bool`   |         | Do not track models usage in Docker Model Runner                                                   |
+| `--gpu`          | `string` | `auto`  | Specify GPU support (none\|auto\|cuda)                                                             |
+| `--port`         | `uint16` | `0`     | Docker container port for Docker Model Runner (default: 12434 for Docker CE, 12435 for Cloud mode) |
 
 
 <!---MARKER_GEN_END-->

--- a/pkg/standalone/ports.go
+++ b/pkg/standalone/ports.go
@@ -5,6 +5,6 @@ const (
 	// controller will listen for requests in Moby environments.
 	DefaultControllerPortMoby = 12434
 	// DefaultControllerPortCloud is the default TCP port on which the
-	// standalone controller will listen for requests in Moby environments.
+	// standalone controller will listen for requests in Cloud environments.
 	DefaultControllerPortCloud = 12435
 )


### PR DESCRIPTION
- install-runner: Document both default ports for Moby and Cloud 
Use "0" as a sentinel default flag value so it's not displayed automatically. The default values are written in the usage string. Hence, the user currently won't be able to set the port to 0 in order to get a random available port.
- standalone: Fix default port comment for Cloud environments