### PR TITLE
Don't bind the bridge gateway IP if we're treating Docker Desktop as Moby

### DIFF
--- a/desktop/context.go
+++ b/desktop/context.go
@@ -142,7 +142,7 @@ func DetectContext(cli *command.DockerCli) (*ModelRunnerContext, error) {
 
 	// Check if we're treating Docker Desktop as regular Moby. This is only for
 	// testing purposes.
-	treatDesktopAsMoby := os.Getenv("_MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY") != ""
+	treatDesktopAsMoby := os.Getenv("_MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY") == "1"
 
 	// Detect the associated engine type.
 	kind := ModelRunnerEngineKindMoby

--- a/pkg/standalone/containers.go
+++ b/pkg/standalone/containers.go
@@ -3,6 +3,7 @@ package standalone
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -106,8 +107,11 @@ func CreateControllerContainer(ctx context.Context, dockerClient *client.Client,
 		},
 	}
 	portBindings := []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: portStr}}
-	if bridgeGatewayIP, err := determineBridgeGatewayIP(ctx, dockerClient); err == nil && bridgeGatewayIP != "" {
-		portBindings = append(portBindings, nat.PortBinding{HostIP: bridgeGatewayIP, HostPort: portStr})
+	if os.Getenv("_MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY") != "1" {
+		// Don't bind the bridge gateway IP if we're treating Docker Desktop as Moby.
+		if bridgeGatewayIP, err := determineBridgeGatewayIP(ctx, dockerClient); err == nil && bridgeGatewayIP != "" {
+			portBindings = append(portBindings, nat.PortBinding{HostIP: bridgeGatewayIP, HostPort: portStr})
+		}
 	}
 	hostConfig.PortBindings = nat.PortMap{
 		nat.Port(portStr + "/tcp"): portBindings,


### PR DESCRIPTION
We can't bind to Docker Desktop VM's internal IP.