### PR TITLE
compose: fix nil pointer panic in standalone runner validation

### DIFF
--- a/commands/compose.go
+++ b/commands/compose.go
@@ -40,8 +40,9 @@ func newUpCommand() *cobra.Command {
 			if err != nil {
 				_ = sendErrorf("Failed to initialize standalone model runner: %v", err)
 				return fmt.Errorf("Failed to initialize standalone model runner: %w", err)
-			} else if (kind == desktop.ModelRunnerEngineKindMoby || kind == desktop.ModelRunnerEngineKindCloud) &&
-				standalone == nil || standalone.gatewayIP == "" || standalone.gatewayPort == 0 {
+			} else if ((kind == desktop.ModelRunnerEngineKindMoby || kind == desktop.ModelRunnerEngineKindCloud) &&
+				standalone == nil) ||
+				(standalone != nil && (standalone.gatewayIP == "" || standalone.gatewayPort == 0)) {
 				return errors.New("unable to determine standalone runner endpoint")
 			}
 


### PR DESCRIPTION
If the engine kind is not Moby or Cloud, the standalone runner is nil and accessing standalone.gatewayIP/gatewayPort causes a panic.