### PR TITLE
context: Detect DD based on the OS and allow WSL2 client

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -66,7 +66,7 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 
 			// Detect the model runner context and create a client for it.
 			var err error
-			modelRunner, err = desktop.DetectContext(dockerCLI)
+			modelRunner, err = desktop.DetectContext(cmd.Context(), dockerCLI)
 			if err != nil {
 				return fmt.Errorf("unable to detect model runner context: %w", err)
 			}


### PR DESCRIPTION
We can use Docker Desktop from within a WSL2 integrated distro, so take this into consideration for Linux clients.
Consider a server with the name "Docker Desktop" to be a Docker Desktop context.