### PR TITLE
chore: desktop: fix missing argument in call to Inspect

### DIFF
--- a/desktop/desktop_test.go
+++ b/desktop/desktop_test.go
@@ -97,7 +97,7 @@ func TestInspectHuggingFaceModel(t *testing.T) {
 		}`)),
 	}, nil)
 
-	model, err := client.Inspect(modelName)
+	model, err := client.Inspect(modelName, false)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedLowercase, model.Tags[0])
 }


### PR DESCRIPTION
Fix UTs by adding the missing argument in call to `Inspect`.
```
make mock && make unit-tests
```