### PR TITLE
context: Use cli's current context instead of "desktop-linux"

### DIFF
--- a/desktop/context.go
+++ b/desktop/context.go
@@ -181,7 +181,7 @@ func DetectContext(ctx context.Context, cli *command.DockerCli) (*ModelRunnerCon
 	// Construct the HTTP client.
 	var client DockerHttpClient
 	if kind == ModelRunnerEngineKindDesktop {
-		dockerClient, err := DockerClientForContext(cli, "desktop-linux")
+		dockerClient, err := DockerClientForContext(cli, cli.CurrentContext())
 		if err != nil {
 			return nil, fmt.Errorf("unable to create model runner client: %w", err)
 		}


### PR DESCRIPTION
E.g., Within a WSL2 integrated user distro with Docker Desktop the default context is named "default".