### PR TITLE
Fix install race detection using more tolerant polling.

### DIFF
--- a/pkg/standalone/containers.go
+++ b/pkg/standalone/containers.go
@@ -79,15 +79,30 @@ func waitForContainerToStart(ctx context.Context, dockerClient *client.Client, c
 	// Unfortunately the Docker API's /containers/{id}/wait API (and the
 	// corresponding Client.ContainerWait method) don't allow waiting for
 	// container startup, so instead we'll take a polling approach.
-	for i := 5; i > 0; i-- {
+	for i := 10; i > 0; i-- {
 		if status, err := dockerClient.ContainerInspect(ctx, containerID); err != nil {
-			return fmt.Errorf("unable to inspect container (%s): %w", containerID[:12], err)
+			// There is a small gap between the time that a container ID and
+			// name are registered and the time that the container is actually
+			// created and shows up in container list and inspect requests:
+			//
+			// https://github.com/moby/moby/blob/de24c536b0ea208a09e0fff3fd896c453da6ef2e/daemon/container.go#L138-L156
+			//
+			// Given that multiple install operations tend to end up tightly
+			// synchronized by the preceeding pull operation and that this
+			// method is specifically designed to work around these race
+			// conditions, we'll allow 404 errors to pass silently (at least up
+			// until the polling time out - unfortunately we can't make the 404
+			// acceptance window any smaller than that because the CUDA-based
+			// containers are large and can take time to create).
+			if !strings.Contains(err.Error(), "No such container") {
+				return fmt.Errorf("unable to inspect container (%s): %w", containerID[:12], err)
+			}
 		} else if status.State.Status == container.StateRunning {
 			return nil
 		}
 		if i > 1 {
 			select {
-			case <-time.After(1 * time.Second):
+			case <-time.After(500 * time.Millisecond):
 			case <-ctx.Done():
 				return errors.New("waiting cancelled")
 			}
@@ -196,7 +211,7 @@ func PruneControllerContainers(ctx context.Context, dockerClient *client.Client,
 
 	// Remove all controller containers.
 	for _, ctr := range containers {
-		if skipRunning && ctr.State == "running" {
+		if skipRunning && ctr.State == container.StateRunning {
 			continue
 		}
 		if len(ctr.Names) > 0 {


### PR DESCRIPTION
See the comments in the code for a full description, but essentially there is a small window (which we often end up in because pull operation deduplication synchronizes model runner installation) where a container ID / name are registered (and we receive a "name is already in use by container" error) before the container actually exists.

To work around this, we'll make our polling a little bit more tolerant.

This commit also replaces a string literal with a new constant.