### PR TITLE
Don't show "Setting context size to -1"

### DIFF
--- a/commands/compose.go
+++ b/commands/compose.go
@@ -41,13 +41,6 @@ func newUpCommand() *cobra.Command {
 			}
 
 			sendInfo("Initializing model runner...")
-			if ctxSize != 4096 {
-				sendInfo(fmt.Sprintf("Setting context size to %d", ctxSize))
-			}
-			if rawRuntimeFlags != "" {
-				sendInfo("Setting raw runtime flags to " + rawRuntimeFlags)
-			}
-
 			kind := modelRunner.EngineKind()
 			standalone, err := ensureStandaloneRunnerAvailable(cmd.Context(), nil)
 			if err != nil {
@@ -61,6 +54,13 @@ func newUpCommand() *cobra.Command {
 
 			if err := downloadModelsOnlyIfNotFound(desktopClient, models); err != nil {
 				return err
+			}
+
+			if ctxSize > 0 && ctxSize != 4096 {
+				sendInfo(fmt.Sprintf("Setting context size to %d", ctxSize))
+			}
+			if rawRuntimeFlags != "" {
+				sendInfo("Setting raw runtime flags to " + rawRuntimeFlags)
 			}
 
 			for _, model := range models {

--- a/commands/compose.go
+++ b/commands/compose.go
@@ -56,7 +56,7 @@ func newUpCommand() *cobra.Command {
 				return err
 			}
 
-			if ctxSize > 0 && ctxSize != 4096 {
+			if ctxSize > 0 {
 				sendInfo(fmt.Sprintf("Setting context size to %d", ctxSize))
 			}
 			if rawRuntimeFlags != "" {


### PR DESCRIPTION
If no context is specified in the Compose YAML, then don't display that we're setting it to the default (-1), because we're not.

Also, leave the "Initializing model runner..." message in place until done.