### PR TITLE
use docker API client interfaces instead of concrete type

### DIFF
--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -17,7 +17,7 @@ const (
 )
 
 // ProbeGPUSupport determines whether or not the Docker engine has GPU support.
-func ProbeGPUSupport(ctx context.Context, dockerClient *client.Client) (GPUSupport, error) {
+func ProbeGPUSupport(ctx context.Context, dockerClient client.SystemAPIClient) (GPUSupport, error) {
 	info, err := dockerClient.Info(ctx)
 	if err != nil {
 		return GPUSupportNone, err

--- a/pkg/standalone/images.go
+++ b/pkg/standalone/images.go
@@ -39,7 +39,7 @@ func controllerImageTagCUDA() string {
 }
 
 // EnsureControllerImage ensures that the controller container image is pulled.
-func EnsureControllerImage(ctx context.Context, dockerClient *client.Client, gpu gpupkg.GPUSupport, printer StatusPrinter) error {
+func EnsureControllerImage(ctx context.Context, dockerClient client.ImageAPIClient, gpu gpupkg.GPUSupport, printer StatusPrinter) error {
 	// Determine the target image.
 	var imageName string
 	switch gpu {
@@ -78,7 +78,7 @@ func EnsureControllerImage(ctx context.Context, dockerClient *client.Client, gpu
 }
 
 // PruneControllerImages removes any unused controller container images.
-func PruneControllerImages(ctx context.Context, dockerClient *client.Client, printer StatusPrinter) error {
+func PruneControllerImages(ctx context.Context, dockerClient client.ImageAPIClient, printer StatusPrinter) error {
 	// Remove the standard image, if present.
 	imageNameCPU := ControllerImage + ":" + controllerImageTagCPU()
 	if _, err := dockerClient.ImageRemove(ctx, imageNameCPU, image.RemoveOptions{}); err == nil {

--- a/pkg/standalone/volumes.go
+++ b/pkg/standalone/volumes.go
@@ -15,7 +15,7 @@ const modelStorageVolumeName = "docker-model-runner-models"
 // EnsureModelStorageVolume ensures that a model storage volume exists, creating
 // it if necessary. It returns the name of the storage volume or any error that
 // occurred.
-func EnsureModelStorageVolume(ctx context.Context, dockerClient *client.Client, printer StatusPrinter) (string, error) {
+func EnsureModelStorageVolume(ctx context.Context, dockerClient client.VolumeAPIClient, printer StatusPrinter) (string, error) {
 	// Try to identify the storage volume.
 	volumes, err := dockerClient.VolumeList(ctx, volume.ListOptions{
 		Filters: filters.NewArgs(
@@ -48,7 +48,7 @@ func EnsureModelStorageVolume(ctx context.Context, dockerClient *client.Client, 
 }
 
 // PruneModelStorageVolumes removes any unused model storage volume(s).
-func PruneModelStorageVolumes(ctx context.Context, dockerClient *client.Client, printer StatusPrinter) error {
+func PruneModelStorageVolumes(ctx context.Context, dockerClient client.VolumeAPIClient, printer StatusPrinter) error {
 	pruned, err := dockerClient.VolumesPrune(ctx, filters.NewArgs(
 		filters.Arg("all", "true"),
 		filters.Arg("label", labelRole+"="+roleModelStorage),


### PR DESCRIPTION
- relates to https://github.com/docker/model-cli/pull/99#discussion_r2156639133

Using the interface allows for alternative implementations (which could be used for testing); where possible, also change the signature to accept a shallower interface that's needed for the operation.