### PR TITLE
Temporarily disable credential configuration copying

### DIFF
--- a/pkg/standalone/containers.go
+++ b/pkg/standalone/containers.go
@@ -292,12 +292,6 @@ func CreateControllerContainer(ctx context.Context, dockerClient *client.Client,
 		_ = dockerClient.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		return fmt.Errorf("failed to start container %s: %w", controllerContainerName, err)
 	}
-
-	// Copy Docker config file if it exists
-	if err := copyDockerConfigToContainer(ctx, dockerClient, resp.ID); err != nil {
-		// Log warning but continue - don't fail container creation
-		printer.Printf("Warning: failed to copy Docker config: %v\n", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Copying a `config.json` with a `"credsStore": "desktop"` entry will cause invocation of the (local-only) `docker-credential-desktop` in remote environments (e.g. CE and Cloud).

I'm not sure how to work around this, but right now the code breaks pulls for public, non-"ai/" repositories from Cloud environments.

I'm also not sure how to make `copyDockerConfigToContainer` safe for concurrent installs, but that's a separate issue.

I've left the supporting code in-place for now, but I think we should triage this until @ilopezluna returns.

This didn't go out with v0.1.30 so there's no rush to find a workaround.  Perhaps we disable it if the local environment is Docker Desktop?  Cloud might be the only scenario where that's the case.