### PR TITLE
fix(compose): make sure any flags defined for compose up also exist for compose down

### DIFF
--- a/docs/reference/docker_model_compose_down.yaml
+++ b/docs/reference/docker_model_compose_down.yaml
@@ -3,10 +3,39 @@ usage: docker model compose down
 pname: docker model compose
 plink: docker_model_compose.yaml
 options:
+    - option: backend
+      value_type: string
+      default_value: llama.cpp
+      description: inference backend to use
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: context-size
+      value_type: int64
+      default_value: "-1"
+      description: context size for the model
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: model
       value_type: stringArray
       default_value: '[]'
       description: model to use
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: runtime-flags
+      value_type: string
+      description: raw runtime flags to pass to the inference engine
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
When compose calls the model provider, the same arguments are passed to both compose
up and compose down. Unless compose down supports any flag supported by compose up, some
of these flags will cause a parsing error and cause compose down to fail.

To fix this, move the flag setup to a dedicated type and function that can be shared
by both commands.

Signed-off-by: Alberto Garcia Hierro <damaso.hierro@docker.com>
