### PR TITLE
Skip copy config on DD local and cloud

### DIFF
--- a/commands/compose.go
+++ b/commands/compose.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/docker/model-cli/pkg/types"
 	"github.com/spf13/pflag"
 	"slices"
 	"strings"
@@ -48,7 +49,7 @@ func newUpCommand() *cobra.Command {
 			if err != nil {
 				_ = sendErrorf("Failed to initialize standalone model runner: %v", err)
 				return fmt.Errorf("Failed to initialize standalone model runner: %w", err)
-			} else if ((kind == desktop.ModelRunnerEngineKindMoby || kind == desktop.ModelRunnerEngineKindCloud) &&
+			} else if ((kind == types.ModelRunnerEngineKindMoby || kind == types.ModelRunnerEngineKindCloud) &&
 				standalone == nil) ||
 				(standalone != nil && (standalone.gatewayIP == "" || standalone.gatewayPort == 0)) {
 				return errors.New("unable to determine standalone runner endpoint")
@@ -79,13 +80,13 @@ func newUpCommand() *cobra.Command {
 			}
 
 			switch kind {
-			case desktop.ModelRunnerEngineKindDesktop:
+			case types.ModelRunnerEngineKindDesktop:
 				_ = setenv("URL", "http://model-runner.docker.internal/engines/v1/")
-			case desktop.ModelRunnerEngineKindMobyManual:
+			case types.ModelRunnerEngineKindMobyManual:
 				_ = setenv("URL", modelRunner.URL("/engines/v1/"))
-			case desktop.ModelRunnerEngineKindCloud:
+			case types.ModelRunnerEngineKindCloud:
 				fallthrough
-			case desktop.ModelRunnerEngineKindMoby:
+			case types.ModelRunnerEngineKindMoby:
 				_ = setenv("URL", fmt.Sprintf("http://%s:%d/engines/v1", standalone.gatewayIP, standalone.gatewayPort))
 			default:
 				return fmt.Errorf("unhandled engine kind: %v", kind)

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/docker/model-cli/pkg/types"
 	"io"
 	"os"
 	"os/signal"
@@ -37,8 +38,8 @@ func newLogsCmd() *cobra.Command {
 			// If we're running in standalone mode, then print the container
 			// logs.
 			engineKind := modelRunner.EngineKind()
-			useStandaloneLogs := engineKind == desktop.ModelRunnerEngineKindMoby ||
-				engineKind == desktop.ModelRunnerEngineKindCloud
+			useStandaloneLogs := engineKind == types.ModelRunnerEngineKindMoby ||
+				engineKind == types.ModelRunnerEngineKindCloud
 			if useStandaloneLogs {
 				dockerClient, err := desktop.DockerClientForContext(dockerCLI, dockerCLI.CurrentContext())
 				if err != nil {

--- a/commands/status.go
+++ b/commands/status.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/docker/model-cli/pkg/types"
 	"os"
 
 	"github.com/docker/cli/cli-plugins/hooks"
@@ -74,13 +75,13 @@ func jsonStatus(standalone *standaloneRunner, status desktop.Status, backendStat
 	var endpoint string
 	kind := modelRunner.EngineKind()
 	switch kind {
-	case desktop.ModelRunnerEngineKindDesktop:
+	case types.ModelRunnerEngineKindDesktop:
 		endpoint = "http://model-runner.docker.internal/engines/v1/"
-	case desktop.ModelRunnerEngineKindMobyManual:
+	case types.ModelRunnerEngineKindMobyManual:
 		endpoint = modelRunner.URL("/engines/v1/")
-	case desktop.ModelRunnerEngineKindCloud:
+	case types.ModelRunnerEngineKindCloud:
 		fallthrough
-	case desktop.ModelRunnerEngineKindMoby:
+	case types.ModelRunnerEngineKindMoby:
 		endpoint = fmt.Sprintf("http://%s:%d/engines/v1", standalone.gatewayIP, standalone.gatewayPort)
 	default:
 		return fmt.Errorf("unhandled engine kind: %v", kind)

--- a/commands/uninstall-runner.go
+++ b/commands/uninstall-runner.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/docker/model-cli/pkg/types"
 
 	"github.com/docker/model-cli/commands/completion"
 	"github.com/docker/model-cli/desktop"
@@ -16,14 +17,14 @@ func newUninstallRunner() *cobra.Command {
 		Short: "Uninstall Docker Model Runner",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Ensure that we're running in a supported model runner context.
-			if kind := modelRunner.EngineKind(); kind == desktop.ModelRunnerEngineKindDesktop {
+			if kind := modelRunner.EngineKind(); kind == types.ModelRunnerEngineKindDesktop {
 				// TODO: We may eventually want to auto-forward this to
 				// docker desktop disable model-runner, but we should first
 				// make install-runner forward in the same way.
 				cmd.Println("Standalone uninstallation not supported with Docker Desktop")
 				cmd.Println("Use `docker desktop disable model-runner` instead")
 				return nil
-			} else if kind == desktop.ModelRunnerEngineKindMobyManual {
+			} else if kind == types.ModelRunnerEngineKindMobyManual {
 				cmd.Println("Standalone uninstallation not supported with MODEL_RUNNER_HOST set")
 				return nil
 			}

--- a/pkg/types/engine.go
+++ b/pkg/types/engine.go
@@ -1,0 +1,37 @@
+package types
+
+// ModelRunnerEngineKind encodes the kind of Docker engine associated with the
+// model runner context.
+type ModelRunnerEngineKind uint8
+
+const (
+	// ModelRunnerEngineKindMoby represents a non-Desktop/Cloud engine on which
+	// the Model CLI command is responsible for managing a Model Runner.
+	ModelRunnerEngineKindMoby ModelRunnerEngineKind = iota
+	// ModelRunnerEngineKindMobyManual represents a non-Desktop/Cloud engine
+	// that's explicitly targeted by a MODEL_RUNNER_HOST environment variable on
+	// which the user is responsible for managing a Model Runner.
+	ModelRunnerEngineKindMobyManual
+	// ModelRunnerEngineKindDesktop represents a Docker Desktop engine. It only
+	// refers to a Docker Desktop Linux engine, i.e. not a Windows container
+	// engine in the case of Docker Desktop for Windows.
+	ModelRunnerEngineKindDesktop
+	// ModelRunnerEngineKindCloud represents a Docker Cloud engine.
+	ModelRunnerEngineKindCloud
+)
+
+// String returns a human-readable engine kind description.
+func (k ModelRunnerEngineKind) String() string {
+	switch k {
+	case ModelRunnerEngineKindMoby:
+		return "Docker Engine"
+	case ModelRunnerEngineKindMobyManual:
+		return "Docker Engine (Manual Install)"
+	case ModelRunnerEngineKindDesktop:
+		return "Docker Desktop"
+	case ModelRunnerEngineKindCloud:
+		return "Docker Cloud"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
This PR is an alternative to https://github.com/docker/model-cli/pull/101.
Instead of disabling the config copy entirely, it simply skips it when coming from a DD client (or a DD cloud server).
To avoid a cyclic dependency, I had to move the types to a shared package.