### PR TITLE
Adds --context-size option to package command

### DIFF
--- a/docs/reference/docker_model_package.yaml
+++ b/docs/reference/docker_model_package.yaml
@@ -3,10 +3,20 @@ short: |
     Package a GGUF file into a Docker model OCI artifact, with optional licenses, and pushes it to the specified registry
 long: |
     Package a GGUF file into a Docker model OCI artifact, with optional licenses, and pushes it to the specified registry
-usage: docker model package --gguf <path> [--license <path>...] --push TARGET
+usage: docker model package --gguf <path> [--license <path>...] [--context-size <tokens>] --push TARGET
 pname: docker model
 plink: docker_model.yaml
 options:
+    - option: context-size
+      value_type: uint64
+      default_value: "0"
+      description: context size in tokens
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: gguf
       value_type: string
       description: absolute path to gguf file (required)

--- a/docs/reference/model_package.md
+++ b/docs/reference/model_package.md
@@ -7,6 +7,7 @@ Package a GGUF file into a Docker model OCI artifact, with optional licenses, an
 
 | Name              | Type          | Default | Description                           |
 |:------------------|:--------------|:--------|:--------------------------------------|
+| `--context-size`  | `uint64`      | `0`     | context size in tokens                |
 | `--gguf`          | `string`      |         | absolute path to gguf file (required) |
 | `-l`, `--license` | `stringArray` |         | absolute path to a license file       |
 | `--push`          | `bool`        |         | push to registry (required)           |

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,13 @@ go 1.24
 toolchain go1.24.4
 
 require (
+	github.com/containerd/errdefs v1.0.0
 	github.com/docker/cli v28.3.0+incompatible
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
-	github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5
+	github.com/docker/model-distribution v0.0.0-20250627163720-aff34abcf3e0
 	github.com/docker/model-runner v0.0.0-20250627142917-26a0a73fbbc0
 	github.com/google/go-containerregistry v0.20.6
 	github.com/mattn/go-isatty v0.0.17
@@ -31,7 +32,6 @@ require (
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/containerd/v2 v2.1.3 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
-	github.com/docker/model-distribution v0.0.0-20250627131521-63daf278071c
+	github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5
 	github.com/docker/model-runner v0.0.0-20250627142917-26a0a73fbbc0
 	github.com/google/go-containerregistry v0.20.6
 	github.com/mattn/go-isatty v0.0.17

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/model-distribution v0.0.0-20250627131521-63daf278071c h1:10BRwHXbCRdIQMvYNjOSPFnGd7ncpc3N7kKG27LQRZY=
 github.com/docker/model-distribution v0.0.0-20250627131521-63daf278071c/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
+github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5 h1:4qs7OwrJJQE1de5kbHg83gm5rmCRQzAwAp8gG/3cLY8=
+github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/docker/model-runner v0.0.0-20250627142917-26a0a73fbbc0 h1:yajuhlGe1xhpWW3eMehQi2RrqiBQiGoi6c6OWiPxMaQ=
 github.com/docker/model-runner v0.0.0-20250627142917-26a0a73fbbc0/go.mod h1:vZJiUZH/7O1CyNsEGi1o4khUT4DVRjcwluuamU9fhuM=
 github.com/dvsekhvalnov/jose2go v0.0.0-20170216131308-f21a8cedbbae/go.mod h1:7BvyPhdbLxMXIYTFPLsyJRFMsKmOZnQmzh6Gb+uquuM=

--- a/go.sum
+++ b/go.sum
@@ -78,10 +78,8 @@ github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHz
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
-github.com/docker/model-distribution v0.0.0-20250627131521-63daf278071c h1:10BRwHXbCRdIQMvYNjOSPFnGd7ncpc3N7kKG27LQRZY=
-github.com/docker/model-distribution v0.0.0-20250627131521-63daf278071c/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
-github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5 h1:4qs7OwrJJQE1de5kbHg83gm5rmCRQzAwAp8gG/3cLY8=
-github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
+github.com/docker/model-distribution v0.0.0-20250627163720-aff34abcf3e0 h1:bve4JZI06Admw+NewtPfrpJXsvRnGKTQvBOEICNC1C0=
+github.com/docker/model-distribution v0.0.0-20250627163720-aff34abcf3e0/go.mod h1:dThpO9JoG5Px3i+rTluAeZcqLGw8C0qepuEL4gL2o/c=
 github.com/docker/model-runner v0.0.0-20250627142917-26a0a73fbbc0 h1:yajuhlGe1xhpWW3eMehQi2RrqiBQiGoi6c6OWiPxMaQ=
 github.com/docker/model-runner v0.0.0-20250627142917-26a0a73fbbc0/go.mod h1:vZJiUZH/7O1CyNsEGi1o4khUT4DVRjcwluuamU9fhuM=
 github.com/dvsekhvalnov/jose2go v0.0.0-20170216131308-f21a8cedbbae/go.mod h1:7BvyPhdbLxMXIYTFPLsyJRFMsKmOZnQmzh6Gb+uquuM=

--- a/vendor/github.com/docker/model-distribution/builder/builder.go
+++ b/vendor/github.com/docker/model-distribution/builder/builder.go
@@ -38,6 +38,12 @@ func (b *Builder) WithLicense(path string) (*Builder, error) {
 	}, nil
 }
 
+func (b *Builder) WithContextSize(size uint64) *Builder {
+	return &Builder{
+		model: mutate.ContextSize(b.model, size),
+	}
+}
+
 // Target represents a build target
 type Target interface {
 	Write(context.Context, types.ModelArtifact, io.Writer) error

--- a/vendor/github.com/docker/model-distribution/internal/mutate/model.go
+++ b/vendor/github.com/docker/model-distribution/internal/mutate/model.go
@@ -16,6 +16,7 @@ type model struct {
 	base            types.ModelArtifact
 	appended        []v1.Layer
 	configMediaType ggcr.MediaType
+	contextSize     *uint64
 }
 
 func (m *model) Descriptor() (types.Descriptor, error) {
@@ -122,6 +123,9 @@ func (m *model) RawConfigFile() ([]byte, error) {
 			return nil, err
 		}
 		cf.RootFS.DiffIDs = append(cf.RootFS.DiffIDs, diffID)
+	}
+	if m.contextSize != nil {
+		cf.Config.ContextSize = m.contextSize
 	}
 	raw, err := json.Marshal(cf)
 	if err != nil {

--- a/vendor/github.com/docker/model-distribution/internal/mutate/mutate.go
+++ b/vendor/github.com/docker/model-distribution/internal/mutate/mutate.go
@@ -20,3 +20,10 @@ func ConfigMediaType(mdl types.ModelArtifact, mt ggcr.MediaType) types.ModelArti
 		configMediaType: mt,
 	}
 }
+
+func ContextSize(mdl types.ModelArtifact, cs uint64) types.ModelArtifact {
+	return &model{
+		base:        mdl,
+		contextSize: &cs,
+	}
+}

--- a/vendor/github.com/docker/model-distribution/types/config.go
+++ b/vendor/github.com/docker/model-distribution/types/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Architecture string            `json:"architecture,omitempty"`
 	Size         string            `json:"size,omitempty"`
 	GGUF         map[string]string `json:"gguf,omitempty"`
+	ContextSize  *uint64           `json:"context_size,omitempty"`
 }
 
 // Descriptor provides metadata about the provenance of the model.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -144,7 +144,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5
+# github.com/docker/model-distribution v0.0.0-20250627163720-aff34abcf3e0
 ## explicit; go 1.23.0
 github.com/docker/model-distribution/builder
 github.com/docker/model-distribution/distribution

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -144,7 +144,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/model-distribution v0.0.0-20250627131521-63daf278071c
+# github.com/docker/model-distribution v0.0.0-20250627152504-c0c68acaabd5
 ## explicit; go 1.23.0
 github.com/docker/model-distribution/builder
 github.com/docker/model-distribution/distribution


### PR DESCRIPTION
* Bumps model-distribution to include https://github.com/docker/model-distribution/pull/92
* Adds optional --context-size flag to `docker model package`

Usage:
```
docker model package --help
Usage:  docker model package --gguf <path> [--license <path>...] [--context-size <tokens>] --push TARGET

Package a GGUF file into a Docker model OCI artifact, with optional licenses, and pushes it to the specified registry

EXPERIMENTAL:
  docker model package is an experimental feature.
  Experimental features provide early access to product functionality. These
  features may change between releases without warning, or can be removed from a
  future release. Learn more about experimental features in our documentation:
  https://docs.docker.com/go/experimental/

Options:
      --context-size uint     context size in tokens
      --gguf string           absolute path to gguf file (required)
  -l, --license stringArray   absolute path to a license file
      --push                  push to registry (required)
 ```
 
 Example:
 ```
> docker model package --gguf /some/path/model.gguf --context-size 2096 --push some/model
Packaging model "some/model"
Adding GGUF file from "/some/path/model.gguf"
Setting context size 2096
Pushing to registry...
Uploaded: 258.06 MB
Model pushed successfully
 ```
 
 Note:
Added to inspect output in a separate PR - https://github.com/docker/model-cli/pull/109