### PR TITLE
Adds context_size to model inspect output

### DIFF
--- a/desktop/api.go
+++ b/desktop/api.go
@@ -49,11 +49,12 @@ type OpenAIModelList struct {
 type Format string
 
 type Config struct {
-	Format       Format `json:"format,omitempty"`
-	Quantization string `json:"quantization,omitempty"`
-	Parameters   string `json:"parameters,omitempty"`
-	Architecture string `json:"architecture,omitempty"`
-	Size         string `json:"size,omitempty"`
+	Format       Format  `json:"format,omitempty"`
+	Quantization string  `json:"quantization,omitempty"`
+	Parameters   string  `json:"parameters,omitempty"`
+	Architecture string  `json:"architecture,omitempty"`
+	Size         string  `json:"size,omitempty"`
+	ContextSize  *uint64 `json:"context_size,omitempty"`
 }
 
 type Model struct {


### PR DESCRIPTION
Includes `context_size` in `model inspect` output **IF** the model artifact provides a value **AND** the targeted version of model runner supports it (requires a version of distribution with https://github.com/docker/model-distribution/pull/92)

This field will not be shown if it is unset in the artifact or if model-runner is too old to provide this value in the response.

```bash
MODEL_RUNNER_HOST=http://localhost:3000 docker model inspect emilycasey003/smollm2
```

```json
{
    "id": "sha256:f07b04c0ce95ce9db15aa26a4ac54e9cafc6c369feb5e7ff2efa527c48a1d4ed",
    "tags": [
        "emilycasey003/smollm2"
    ],
    "created": 1751039531,
    "config": {
        "format": "gguf",
        "quantization": "IQ2_XXS/Q4_K_M",
        "parameters": "361.82 M",
        "architecture": "llama",
        "size": "256.35 MiB",
        "context_size": 2096
    }
}
```
