### PR TITLE
chore: use constant format strings

### DIFF
--- a/commands/compose.go
+++ b/commands/compose.go
@@ -129,7 +129,7 @@ func newMetadataCommand(upCmd, downCmd *cobra.Command) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf(string(jsonMetadata))
+			fmt.Print(string(jsonMetadata))
 			return nil
 		},
 	}

--- a/commands/run.go
+++ b/commands/run.go
@@ -15,7 +15,7 @@ import (
 func newRunCmd() *cobra.Command {
 	var debug bool
 
-	cmdArgs := "MODEL [PROMPT]"
+	const cmdArgs = "MODEL [PROMPT]"
 	c := &cobra.Command{
 		Use:   "run " + cmdArgs,
 		Short: "Run a model and interact with it using a submitted prompt or chat mode",

--- a/commands/unload.go
+++ b/commands/unload.go
@@ -12,7 +12,7 @@ func newUnloadCmd() *cobra.Command {
 	var all bool
 	var backend string
 
-	cmdArgs := "(MODEL [MODEL ...] [--backend BACKEND] | --all)"
+	const cmdArgs = "(MODEL [MODEL ...] [--backend BACKEND] | --all)"
 	c := &cobra.Command{
 		Use:   "unload " + cmdArgs,
 		Short: "Unload running models",


### PR DESCRIPTION
Fix `non-constant format string`.

```
$ go vet ./...
# github.com/docker/model-cli/commands
# [github.com/docker/model-cli/commands]
commands/compose.go:132:15: non-constant format string in call to fmt.Printf
commands/run.go:97:5: non-constant format string in call to fmt.Errorf
commands/run.go:103:22: non-constant format string in call to fmt.Errorf
commands/unload.go:43:6: non-constant format string in call to fmt.Errorf
commands/unload.go:52:5: non-constant format string in call to fmt.Errorf
```