### PR TITLE
run: Use the provided model reference 

### DIFF
--- a/commands/ps.go
+++ b/commands/ps.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"strings"
 	"time"
 
 	"github.com/docker/go-units"
@@ -50,8 +51,12 @@ func psTable(ps []desktop.BackendStatus) string {
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 
 	for _, status := range ps {
+		modelName := status.ModelName
+		if strings.HasPrefix(modelName, "sha256:") {
+			modelName = modelName[7:19]
+		}
 		table.Append([]string{
-			status.ModelName,
+			modelName,
 			status.BackendName,
 			status.Mode,
 			units.HumanDuration(time.Since(status.LastUsed)) + " ago",

--- a/commands/run.go
+++ b/commands/run.go
@@ -37,17 +37,15 @@ func newRunCmd() *cobra.Command {
 				return fmt.Errorf("unable to initialize standalone model runner: %w", err)
 			}
 
-			modelDetail, err := desktopClient.Inspect(model, false)
+			_, err := desktopClient.Inspect(model, false)
 			if err != nil {
 				if !errors.Is(err, desktop.ErrNotFound) {
-					return handleNotRunningError(handleClientError(err, "Failed to list models"))
+					return handleNotRunningError(handleClientError(err, "Failed to inspect model"))
 				}
 				cmd.Println("Unable to find model '" + model + "' locally. Pulling from the server.")
 				if err := pullModel(cmd, desktopClient, model); err != nil {
 					return err
 				}
-			} else if model != modelDetail.Tags[0] {
-				model = modelDetail.Tags[0]
 			}
 
 			if prompt != "" {


### PR DESCRIPTION
This mimics the docker run + docker ps behaviour to display the used (model) reference.

Before:
```
$ docker model run sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 hi
...
$ docker model ps
MODEL NAME                           BACKEND    MODE        LAST USED
index.docker.io/ai/smollm2-2:latest  llama.cpp  completion  2 seconds ago
```

Now:
```
$ docker model run sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 hi
...
$ docker model ps
MODEL NAME                                                               BACKEND    MODE        LAST USED
sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9  llama.cpp  completion  2 seconds ago
```

Moreover, with the second commit, the previous `ps` output will look like this:
```
$ docker model ps
MODEL NAME    BACKEND    MODE        LAST USED
354bf30d0aa3  llama.cpp  completion  8 seconds ago
```
