### PR TITLE
fix: align DMR URLs to consistently include trailing slash

### DIFF
--- a/commands/compose.go
+++ b/commands/compose.go
@@ -88,7 +88,7 @@ func newUpCommand() *cobra.Command {
 			case types.ModelRunnerEngineKindCloud:
 				fallthrough
 			case types.ModelRunnerEngineKindMoby:
-				_ = setenv("URL", fmt.Sprintf("http://%s:%d/engines/v1", standalone.gatewayIP, standalone.gatewayPort))
+				_ = setenv("URL", fmt.Sprintf("http://%s:%d/engines/v1/", standalone.gatewayIP, standalone.gatewayPort))
 			default:
 				return fmt.Errorf("unhandled engine kind: %v", kind)
 			}

--- a/commands/status.go
+++ b/commands/status.go
@@ -82,7 +82,7 @@ func jsonStatus(standalone *standaloneRunner, status desktop.Status, backendStat
 	case types.ModelRunnerEngineKindCloud:
 		fallthrough
 	case types.ModelRunnerEngineKindMoby:
-		endpoint = fmt.Sprintf("http://%s:%d/engines/v1", standalone.gatewayIP, standalone.gatewayPort)
+		endpoint = fmt.Sprintf("http://%s:%d/engines/v1/", standalone.gatewayIP, standalone.gatewayPort)
 	default:
 		return fmt.Errorf("unhandled engine kind: %v", kind)
 	}


### PR DESCRIPTION
Some engine kinds had a trailing slash, while others did not. This could lead
to subtle bugs depending how the URL is consumed. This commit ensures all
returned URLs have the trailing slash.
