### PR TITLE
Improve progress message

### DIFF
--- a/desktop/api.go
+++ b/desktop/api.go
@@ -1,9 +1,18 @@
 package desktop
 
-// ProgressMessage represents a message sent during model pull operations
+// ProgressMessage represents a structured message for progress reporting
 type ProgressMessage struct {
 	Type    string `json:"type"`    // "progress", "success", or "error"
-	Message string `json:"message"` // Human-readable message
+	Message string `json:"message"` // Deprecated: the message should be defined by clients based on Message.Total and Message.Layer
+	Total   uint64 `json:"total"`
+	Pulled  uint64 `json:"pulled"` // Deprecated: use Layer.Current
+	Layer   Layer  `json:"layer"`  // Current layer information
+}
+
+type Layer struct {
+	ID      string // Layer ID
+	Size    uint64 // Layer size
+	Current uint64 // Current bytes transferred
 }
 
 type OpenAIChatMessage struct {


### PR DESCRIPTION
Depends on: https://github.com/docker/model-runner/pull/99
Include total in progress message.

The model-distribution do not report the accumulated progress per layer.
For example, if a model contain 2 layers of 10 bytes each, and you have already pulled one of the layers, and you get a progress message for the next byte, the message received but model distribution will be like:
`{"type":"progress","total":20,"pulled":1,"layer":{"ID":"layer-id-2","Size":10,"Current":1}}`

From this message the client do not have any way to understand the real progress 11 bytes of 20 bytes.
Because of that I keep track of the progress per layer in this PR.
Ideally this should be calculated in model-distribution but I don't know how to do it without a big change set.