### PR TITLE
Enable completion for `tag` and disable it for `package`

### DIFF
--- a/commands/package.go
+++ b/commands/package.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path/filepath"
 
+	"github.com/docker/model-cli/commands/completion"
 	"github.com/docker/model-cli/desktop"
 	"github.com/docker/model-distribution/builder"
 	"github.com/docker/model-distribution/registry"
@@ -67,6 +68,7 @@ func newPackagedCmd() *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	c.Flags().StringVar(&opts.ggufPath, "gguf", "", "absolute path to gguf file (required)")

--- a/commands/tag.go
+++ b/commands/tag.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/docker/model-cli/commands/completion"
 	"github.com/docker/model-cli/desktop"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
@@ -28,6 +29,7 @@ func newTagCmd() *cobra.Command {
 			}
 			return tagModel(cmd, desktopClient, args[0], args[1])
 		},
+		ValidArgsFunction: completion.ModelNames(getDesktopClient, 1),
 	}
 	return c
 }


### PR DESCRIPTION
Enable completion for `tag` and disable it for `package`.

```
$ docker model tag <TAB>
ai/gemma3:1B-Q4_K_M               ai/mistral-nemo:latest            ai/smollm2                        ghcr.io/ilopezluna/smollm2
ai/llama3.2                       ai/qwen3:0.6B-Q4_0                emilycasey003/smollm2             kevinwittek212/qwen3:0.6B-Q4_K_M
```