### PR TITLE
rm: show untagged model information

### DIFF
--- a/commands/rm.go
+++ b/commands/rm.go
@@ -29,7 +29,7 @@ func newRemoveCmd() *cobra.Command {
 			}
 			response, err := desktopClient.Remove(args, force)
 			if response != "" {
-				cmd.Println(response)
+				cmd.Print(response)
 			}
 			if err != nil {
 				err = handleClientError(err, "Failed to remove model")

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -429,19 +429,23 @@ func (c *Client) Remove(models []string, force bool) (string, error) {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
+		var bodyStr string
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			bodyStr = fmt.Sprintf("(failed to read response body: %v)", err)
+		} else {
+			bodyStr = string(body)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			modelRemoved += bodyStr
+		} else {
 			if resp.StatusCode == http.StatusNotFound {
 				return modelRemoved, fmt.Errorf("no such model: %s", model)
 			}
-			var bodyStr string
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				bodyStr = fmt.Sprintf("(failed to read response body: %v)", err)
-			} else {
-				bodyStr = string(body)
-			}
 			return modelRemoved, fmt.Errorf("removing %s failed with status %s: %s", model, resp.Status, bodyStr)
 		}
+
 		modelRemoved += fmt.Sprintf("Model %s removed successfully\n", model)
 	}
 	return modelRemoved, nil


### PR DESCRIPTION
Show untagged model information on `docker model rm` to make it more similar to `docker image rm`.

Requires https://github.com/docker/model-runner/pull/100 which requires https://github.com/docker/model-distribution/commit/08f8ace513ff803b147a968d1ff36d39a1e536ef.

You can test it by running https://github.com/docker/model-runner/pull/100 in a separate terminal and then installing and trying out these changes.
```
$ MODEL_RUNNER_PORT=8080 make run
```

```
$ make install

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model tag ai/smollm2 dorin/smollm2
Model "ai/smollm2" tagged successfully with "index.docker.io/dorin/smollm2:latest"

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model inspect ai/smollm2
{
   "id": "sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9",
   "tags": [
       "ai/smollm2",
       "index.docker.io/dorin/smollm2:latest"
   ],
   "created": 1742816981,
   "config": {
       "format": "gguf",
       "quantization": "IQ2_XXS/Q4_K_M",
       "parameters": "361.82 M",
       "architecture": "llama",
       "size": "256.35 MiB"
   }
}

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model rm -f 354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9
Untagged: ai/smollm2
Untagged: index.docker.io/dorin/smollm2:latest
Model sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 removed successfully
```
