### PR TITLE
Allow tag with implicit registry

### DIFF
--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -605,7 +605,7 @@ func (c *Client) handleQueryError(err error, path string) error {
 	return fmt.Errorf("error querying %s: %w", path, err)
 }
 
-func (c *Client) Tag(source, targetRepo, targetTag string) (string, error) {
+func (c *Client) Tag(source, targetRepo, targetTag string) error {
 	source = normalizeHuggingFaceModelName(source)
 	// Check if the source is a model ID, and expand it if necessary
 	if !strings.Contains(strings.Trim(source, "/"), "/") {
@@ -625,19 +625,17 @@ func (c *Client) Tag(source, targetRepo, targetTag string) (string, error) {
 
 	resp, err := c.doRequest(http.MethodPost, tagPath, nil)
 	if err != nil {
-		return "", c.handleQueryError(err, tagPath)
+		return c.handleQueryError(err, tagPath)
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("tagging failed with status %s: %s", resp.Status, string(body))
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %w", err)
+		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	return string(body), nil
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("tagging failed with status %s: %s", resp.Status, string(body))
+	}
+
+	return nil
 }

--- a/desktop/desktop_test.go
+++ b/desktop/desktop_test.go
@@ -193,8 +193,7 @@ func TestTagHuggingFaceModel(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString("Tag created successfully")),
 	}, nil)
 
-	_, err := client.Tag(sourceModel, targetRepo, targetTag)
-	assert.NoError(t, err)
+	assert.NoError(t, client.Tag(sourceModel, targetRepo, targetTag))
 }
 
 func TestInspectOpenAIHuggingFaceModel(t *testing.T) {


### PR DESCRIPTION
**Description**:
* When the `<target>` in `docker model tag <source> <target>` does not explicitly specify the registry, do not add the implicit `index.docker.io` to the repo name sent to the registry. Instead, allow the registry to remain implicit.
* Allows the CLI to decide what message is printed on success instead of printing whatever is sent from the backend.

**Example**:
```
> docker model tag ai/smollm2 emilycasey003/smollm2
Model "ai/smollm2" tagged successfully with "emilycasey003/smollm2"

> docker model ls
MODEL NAME                         PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED       SIZE
ai/smollm2                         361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 months ago  256.35 MiB
emilycasey003/smollm2:latest       361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  3 months ago  256.35 MiB
```

**Note**: while we likely also want to do this with the implicit `:latest` tag so it doesn't show up explicitly in the model list when it wasn't specified, this would require the model-runner API to [accept a missing tag query param](https://github.com/docker/model-runner/blob/main/pkg/inference/models/manager.go#L442-L445) and any version of the CLI that depended on this change would be incompatible with older version of model runner.