### PR TITLE
Make "ai/" the default namespace

### DIFF
--- a/commands/completion/functions.go
+++ b/commands/completion/functions.go
@@ -3,6 +3,7 @@ package completion
 import (
 	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 func NoComplete(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -30,4 +31,13 @@ func ModelNames(desktopClient func() *desktop.Client, limit int) cobra.Completio
 		}
 		return names, cobra.ShellCompDirectiveNoFileComp
 	}
+}
+
+// ensures the model string contains a slash, and if not, prepends "ai/".
+func AddDefaultNamespace(model string) string {
+	if !strings.Contains(model, "/") {
+		return "ai/" + model
+	}
+
+	return model
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -100,6 +100,7 @@ func newRunCmd() *cobra.Command {
 			}
 
 			model := args[0]
+			model = completion.AddDefaultNamespace(model)
 			prompt := ""
 			if len(args) == 1 {
 				if debug {


### PR DESCRIPTION
So we can run commands like:

  docker model run gpt-oss

without the "ai/".

This would be similar to ollama where the "library/" is typically not specified.