### PR TITLE
Make "ai/" the default namespace

### DIFF
--- a/commands/completion/functions.go
+++ b/commands/completion/functions.go
@@ -1,6 +1,8 @@
 package completion
 
 import (
+	"strings"
+
 	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
 )
@@ -30,4 +32,13 @@ func ModelNames(desktopClient func() *desktop.Client, limit int) cobra.Completio
 		}
 		return names, cobra.ShellCompDirectiveNoFileComp
 	}
+}
+
+// ensures the model string contains a slash, and if not, prepends "ai/".
+func AddDefaultNamespace(model string) string {
+	if strings.Contains(model, "/") {
+		return model
+	}
+
+	return "ai/" + model
 }

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -23,6 +23,8 @@ func newInspectCmd() *cobra.Command {
 						"See 'docker model inspect --help' for more information",
 				)
 			}
+
+			args[0] = completion.AddDefaultNamespace(args[0])
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -47,7 +49,7 @@ func newInspectCmd() *cobra.Command {
 }
 
 func inspectModel(args []string, openai bool, remote bool, desktopClient *desktop.Client) (string, error) {
-	modelName := args[0]
+	modelName := completion.AddDefaultNamespace(args[0])
 	if openai {
 		model, err := desktopClient.InspectOpenAI(modelName)
 		if err != nil {

--- a/commands/list.go
+++ b/commands/list.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/docker/go-units"
@@ -127,6 +128,7 @@ func prettyPrintModels(models []dmrm.Model) string {
 			continue
 		}
 		for _, tag := range m.Tags {
+			tag = strings.TrimPrefix(tag, "ai/")
 			appendRow(table, tag, m)
 		}
 	}

--- a/commands/package.go
+++ b/commands/package.go
@@ -63,7 +63,7 @@ func newPackagedCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.tag = args[0]
+			opts.tag = completion.AddDefaultNamespace(args[0])
 			if err := packageModel(cmd, opts); err != nil {
 				cmd.PrintErrln("Failed to package model")
 				return fmt.Errorf("package model: %w", err)

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -41,6 +41,7 @@ func newPullCmd() *cobra.Command {
 }
 
 func pullModel(cmd *cobra.Command, desktopClient *desktop.Client, model string, ignoreRuntimeMemoryCheck bool) error {
+	model = completion.AddDefaultNamespace(model)
 	var progress func(string)
 	if isatty.IsTerminal(os.Stdout.Fd()) {
 		progress = TUIProgress

--- a/commands/push.go
+++ b/commands/push.go
@@ -34,6 +34,7 @@ func newPushCmd() *cobra.Command {
 }
 
 func pushModel(cmd *cobra.Command, desktopClient *desktop.Client, model string) error {
+	model = completion.AddDefaultNamespace(model)
 	response, progressShown, err := desktopClient.Push(model, TUIProgress)
 
 	// Add a newline before any output (success or error) if progress was shown.

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -21,6 +21,8 @@ func newRemoveCmd() *cobra.Command {
 						"See 'docker model rm --help' for more information",
 				)
 			}
+
+			args[0] = completion.AddDefaultNamespace(args[0])
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/commands/run.go
+++ b/commands/run.go
@@ -101,7 +101,7 @@ func newRunCmd() *cobra.Command {
 				return err
 			}
 
-			model := args[0]
+			model := completion.AddDefaultNamespace(args[0])
 			prompt := ""
 			args_len := len(args)
 			if args_len > 1 {

--- a/commands/unload.go
+++ b/commands/unload.go
@@ -54,6 +54,8 @@ func newUnloadCmd() *cobra.Command {
 					"See 'docker model unload --help' for more information.",
 			)
 		}
+
+		args[0] = completion.AddDefaultNamespace(args[0])
 		return nil
 	}
 	c.Flags().BoolVar(&all, "all", false, "Unload all running models")


### PR DESCRIPTION
So we can run commands like:

  docker model run gpt-oss

without the "ai/".

This would be similar to ollama where the "library/" is typically not specified.