### PR TITLE
fix(standalone): don't copy config if Desktop is treated as Moby

### DIFF
--- a/pkg/standalone/containers.go
+++ b/pkg/standalone/containers.go
@@ -31,7 +31,8 @@ const controllerContainerName = "docker-model-runner"
 // It does nothing for Desktop and Cloud engine kinds.
 func copyDockerConfigToContainer(ctx context.Context, dockerClient *client.Client, containerID string, engineKind types.ModelRunnerEngineKind) error {
 	// Do nothing for Desktop and Cloud engine kinds
-	if engineKind == types.ModelRunnerEngineKindDesktop || engineKind == types.ModelRunnerEngineKindCloud {
+	if engineKind == types.ModelRunnerEngineKindDesktop || engineKind == types.ModelRunnerEngineKindCloud ||
+		os.Getenv("_MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY") == "1" {
 		return nil
 	}
 


### PR DESCRIPTION
Without this patch, we were copying the Docker config inside the `docker/model-runner` container running in Docker Desktop, and this made methods like `pull` fail due to the missing `docker-credential-desktop`.

```
$ _MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY=1 docker model run ai/smollm2
Unable to find model 'ai/smollm2' locally. Pulling from the server.
Failed to pull model: pulling ai/smollm2 failed with status 500 Internal Server Error: error while pulling model: reading model from registry: failed to pull model "ai/smollm2": UNKNOWN - error getting credentials - err: exec: "docker-credential-desktop": executable file not found in $PATH, out: ``
```

Now everything works as expected:
```
$ _MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY=1 docker model install-runner
latest: Pulling from docker/model-runner Digest: sha256:00fba948428db7f9a750a7a74b3af55ab99801d0a6f1a1d7b68169a948661342
Status: Image is up to date for docker/model-runner:latest

Successfully pulled docker/model-runner:latest
Starting model runner container docker-model-runner...
$ _MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY=1 docker model pull ai/smollm2
Downloaded 270.60MB of 270.60MB
Model pulled successfully
$ _MODEL_RUNNER_TREAT_DESKTOP_AS_MOBY=1 docker model ls
MODEL NAME  PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED       SIZE
ai/smollm2  361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  5 months ago  256.35 MiB
```