### PR TITLE
feat(command): remove experimental CLI annotation

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -83,8 +83,6 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		TraverseChildren: plugin.RunningStandalone(),
 	}
 
-	markCommandExperimental(rootCmd)
-
 	// Initialize client options and register their flags if running in
 	// standalone mode.
 	if plugin.RunningStandalone() {
@@ -114,17 +112,4 @@ func NewRootCmd(cli *command.DockerCli) *cobra.Command {
 		newUnloadCmd(),
 	)
 	return rootCmd
-}
-
-const annotationExperimentalCLI = "experimentalCLI"
-
-func markCommandExperimental(c *cobra.Command) {
-	if _, ok := c.Annotations[annotationExperimentalCLI]; ok {
-		return
-	}
-	if c.Annotations == nil {
-		c.Annotations = make(map[string]string)
-	}
-	c.Annotations[annotationExperimentalCLI] = ""
-	c.Short += " (EXPERIMENTAL)"
 }

--- a/docs/reference/docker_model.yaml
+++ b/docs/reference/docker_model.yaml
@@ -42,7 +42,7 @@ clink:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_compose.yaml
+++ b/docs/reference/docker_model_compose.yaml
@@ -22,7 +22,7 @@ options:
 deprecated: false
 hidden: true
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_compose_down.yaml
+++ b/docs/reference/docker_model_compose_down.yaml
@@ -15,7 +15,7 @@ inherited_options:
 deprecated: false
 hidden: true
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_compose_metadata.yaml
+++ b/docs/reference/docker_model_compose_metadata.yaml
@@ -17,7 +17,7 @@ inherited_options:
 deprecated: false
 hidden: true
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_compose_up.yaml
+++ b/docs/reference/docker_model_compose_up.yaml
@@ -55,7 +55,7 @@ inherited_options:
 deprecated: false
 hidden: true
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_configure.yaml
+++ b/docs/reference/docker_model_configure.yaml
@@ -18,7 +18,7 @@ options:
 deprecated: false
 hidden: true
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_df.yaml
+++ b/docs/reference/docker_model_df.yaml
@@ -7,7 +7,7 @@ plink: docker_model.yaml
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_inspect.yaml
+++ b/docs/reference/docker_model_inspect.yaml
@@ -29,7 +29,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_install-runner.yaml
+++ b/docs/reference/docker_model_install-runner.yaml
@@ -39,7 +39,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_list.yaml
+++ b/docs/reference/docker_model_list.yaml
@@ -49,7 +49,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_logs.yaml
+++ b/docs/reference/docker_model_logs.yaml
@@ -29,7 +29,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_package.yaml
+++ b/docs/reference/docker_model_package.yaml
@@ -52,7 +52,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_ps.yaml
+++ b/docs/reference/docker_model_ps.yaml
@@ -7,7 +7,7 @@ plink: docker_model.yaml
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_pull.yaml
+++ b/docs/reference/docker_model_pull.yaml
@@ -39,7 +39,7 @@ examples: |-
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_push.yaml
+++ b/docs/reference/docker_model_push.yaml
@@ -7,7 +7,7 @@ plink: docker_model.yaml
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_rm.yaml
+++ b/docs/reference/docker_model_rm.yaml
@@ -19,7 +19,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_run.yaml
+++ b/docs/reference/docker_model_run.yaml
@@ -71,7 +71,7 @@ examples: |-
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_status.yaml
+++ b/docs/reference/docker_model_status.yaml
@@ -19,7 +19,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_tag.yaml
+++ b/docs/reference/docker_model_tag.yaml
@@ -8,7 +8,7 @@ plink: docker_model.yaml
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_uninstall-runner.yaml
+++ b/docs/reference/docker_model_uninstall-runner.yaml
@@ -28,7 +28,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_unload.yaml
+++ b/docs/reference/docker_model_unload.yaml
@@ -27,7 +27,7 @@ options:
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_model_version.yaml
+++ b/docs/reference/docker_model_version.yaml
@@ -7,7 +7,7 @@ plink: docker_model.yaml
 deprecated: false
 hidden: false
 experimental: false
-experimentalcli: true
+experimentalcli: false
 kubernetes: false
 swarm: false
 

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -1,7 +1,7 @@
 # docker model
 
 <!---MARKER_GEN_START-->
-Docker Model Runner (EXPERIMENTAL)
+Docker Model Runner
 
 ### Subcommands
 


### PR DESCRIPTION
Remove the experimental CLI annotation(s).

Before:
```
$ docker model
Usage:  docker model COMMAND

Docker Model Runner (EXPERIMENTAL)

EXPERIMENTAL:
  docker model is an experimental feature.
  Experimental features provide early access to product functionality. These
  features may change between releases without warning, or can be removed from a
  future release. Learn more about experimental features in our documentation:
  https://docs.docker.com/go/experimental/

Commands:
...
```

Now:
```
$ docker model
Usage:  docker model COMMAND

Docker Model Runner

Commands:
...
```
