### PR TITLE
fix(CLI hint): DMR is now under AI

### DIFF
--- a/commands/utils.go
+++ b/commands/utils.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	enableViaCLI = "Enable Docker Model Runner via the CLI → docker desktop enable model-runner"
-	enableViaGUI = "Enable Docker Model Runner via the GUI → Go to Settings->Features in development->Enable Docker Model Runner"
+	enableViaGUI = "Enable Docker Model Runner via the GUI → Go to Settings->AI->Enable Docker Model Runner"
 )
 
 var notRunningErr = fmt.Errorf("Docker Model Runner is not running. Please start it and try again.\n")


### PR DESCRIPTION
Docker Model Runner is now under the AI section in Docker Desktop.

<img width="1382" height="832" src="https://github.com/user-attachments/assets/54ae5eb9-e66e-488a-a6d5-63555fdd7016" />
