### PR TITLE
feat(list): filter based on model arg

### DIFF
--- a/commands/completion/functions.go
+++ b/commands/completion/functions.go
@@ -1,6 +1,8 @@
 package completion
 
 import (
+	"strings"
+
 	"github.com/docker/model-cli/desktop"
 	"github.com/spf13/cobra"
 )
@@ -29,5 +31,58 @@ func ModelNames(desktopClient func() *desktop.Client, limit int) cobra.Completio
 			names = append(names, m.Tags...)
 		}
 		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// ModelNamesAndTags offers completion that matches the base model name along with its tags.
+// If the model has multiple tags, match both the base model name and each tag.
+func ModelNamesAndTags(desktopClient func() *desktop.Client, limit int) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// HACK: Invoke rootCmd's PersistentPreRunE, which is needed for context
+		// detection and client initialization. This function isn't invoked
+		// automatically on autocompletion paths.
+		cmd.Parent().PersistentPreRunE(cmd, args)
+
+		if limit > 0 && len(args) >= limit {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		models, err := desktopClient().List()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		var names []string
+
+		modelNames := make(map[string]bool)
+		modelTags := make(map[string][]string)
+
+		for _, m := range models {
+			for _, tag := range m.Tags {
+				// Extract model name (everything before the first colon or the full tag if no colon).
+				modelName, _, _ := strings.Cut(tag, ":")
+				modelNames[modelName] = true
+				modelTags[modelName] = append(modelTags[modelName], tag)
+			}
+		}
+
+		for name := range modelNames {
+			// If model has multiple tags, suggest the base model name and all specific tags.
+			if len(modelTags[name]) > 1 {
+				names = append(names, name)
+				for _, tag := range modelTags[name] {
+					names = append(names, tag)
+					// If this model doesn't have a tag, also add the :latest variant.
+					if tag == name {
+						names = append(names, tag+":latest")
+					}
+				}
+			} else {
+				// If only one tag, just suggest that tag to avoid duplication.
+				names = append(names, modelTags[name][0])
+			}
+		}
+
+		return names, cobra.ShellCompDirectiveNoSpace
 	}
 }


### PR DESCRIPTION
Filter based on model argument.
The completion suggests the base model name along with its tags. If the model has multiple tags, suggest both the base model name and each tag.

```
$ make install

$ docker model ls ai/smollm2
ai/smollm2            ai/smollm2:135M-Q2_K  ai/smollm2:latest

$ docker model ls ai/smollm2
MODEL NAME            PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED       SIZE
ai/smollm2            361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  5 months ago  256.35 MiB
ai/smollm2:135M-Q2_K  134.52 M    Q2_K            llama         eba11bf8f361  4 months ago  82.41 MiB

$ docker model ls ai/smollm2:latest
MODEL NAME  PARAMETERS  QUANTIZATION    ARCHITECTURE  MODEL ID      CREATED       SIZE
ai/smollm2  361.82 M    IQ2_XXS/Q4_K_M  llama         354bf30d0aa3  5 months ago  256.35 MiB

$ docker model ls ai/smollm2:135M-Q2_K
MODEL NAME            PARAMETERS  QUANTIZATION  ARCHITECTURE  MODEL ID      CREATED       SIZE
ai/smollm2:135M-Q2_K  134.52 M    Q2_K          llama         eba11bf8f361  4 months ago  82.41 MiB
```