### PR TITLE
Improve CUDA detection

### DIFF
--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -19,18 +19,30 @@ const (
 
 // ProbeGPUSupport determines whether or not the Docker engine has GPU support.
 func ProbeGPUSupport(ctx context.Context, dockerClient client.SystemAPIClient) (GPUSupport, error) {
-	info, err := dockerClient.Info(ctx)
-	if err != nil {
-		return GPUSupportNone, err
-	}
-	if _, hasNvidia := info.Runtimes["nvidia"]; hasNvidia {
-		return GPUSupportCUDA, nil
-	}
-
-	// If nvidia runtime is not listed, try searching for nvidia-container-runtime on PATH
+	// First search for nvidia-container-runtime on PATH
 	if _, err := exec.LookPath("nvidia-container-runtime"); err == nil {
 		return GPUSupportCUDA, nil
 	}
 
+	// Next look for explicitly configured nvidia runtime. This is not required in Docker 19.03+ but
+	// may be configured on some systems
+	hasNvidia, err := HasNVIDIARuntime(ctx, dockerClient)
+	if err != nil {
+		return GPUSupportNone, err
+	}
+	if hasNvidia {
+		return GPUSupportCUDA, nil
+	}
+
 	return GPUSupportNone, nil
+}
+
+// HasNVIDIARuntime determines whether there is an nvidia runtime available
+func HasNVIDIARuntime(ctx context.Context, dockerClient client.SystemAPIClient) (bool, error) {
+	info, err := dockerClient.Info(ctx)
+	if err != nil {
+		return false, err
+	}
+	_, hasNvidia := info.Runtimes["nvidia"]
+	return hasNvidia, nil
 }

--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -2,6 +2,7 @@ package gpu
 
 import (
 	"context"
+	"os/exec"
 
 	"github.com/docker/docker/client"
 )
@@ -25,5 +26,11 @@ func ProbeGPUSupport(ctx context.Context, dockerClient client.SystemAPIClient) (
 	if _, hasNvidia := info.Runtimes["nvidia"]; hasNvidia {
 		return GPUSupportCUDA, nil
 	}
+
+	// If nvidia runtime is not listed, try searching for nvidia-container-runtime on PATH
+	if _, err := exec.LookPath("nvidia-container-runtime"); err == nil {
+		return GPUSupportCUDA, nil
+	}
+
 	return GPUSupportNone, nil
 }

--- a/pkg/standalone/containers.go
+++ b/pkg/standalone/containers.go
@@ -268,7 +268,9 @@ func CreateControllerContainer(ctx context.Context, dockerClient *client.Client,
 		nat.Port(portStr + "/tcp"): portBindings,
 	}
 	if gpu == gpupkg.GPUSupportCUDA {
-		hostConfig.Runtime = "nvidia"
+		if ok, err := gpupkg.HasNVIDIARuntime(ctx, dockerClient); err == nil && ok {
+			hostConfig.Runtime = "nvidia"
+		}
 		hostConfig.DeviceRequests = []container.DeviceRequest{{Count: -1, Capabilities: [][]string{{"gpu"}}}}
 	}
 


### PR DESCRIPTION
With Docker 19.03+, NVIDIA Container Toolkit integrates via an OCI prestart hook instead of a separate `nvidia` runtime. When checking for CUDA support, assume existence of the runtime hook (`nvidia-container-runtime`) on the path indicates CUDA support.

Older setups with `nvidia-docker2` we may still require `--runtime=nvidia`. Check for this when creating the containers and only supply --runtime=nvidia when such a runtime is available. Assume the existence of the runtime also implies CUDA support.

## Summary by Sourcery

Enhance GPU support detection to handle both Docker 19.03+ prestart hook integration and legacy nvidia runtime configurations

Enhancements:
- ProbeGPUSupport now first checks for the nvidia-container-runtime binary on PATH and assumes CUDA support if found
- Extract HasNVIDIARuntime helper to query the Docker engine for an "nvidia" runtime
- Conditionally set hostConfig.Runtime to "nvidia" in container creation only when the nvidia runtime is actually available